### PR TITLE
Address Cargo Stylus Feedback

### DIFF
--- a/src/check.rs
+++ b/src/check.rs
@@ -15,7 +15,7 @@ use ethers::{
     core::types::spoof,
     providers::{Provider, RawCall},
 };
-use eyre::eyre;
+use eyre::{bail, eyre};
 
 use crate::constants::PROGRAM_UP_TO_DATE_ERR;
 use crate::{
@@ -147,9 +147,9 @@ where
             if e.to_string().contains(PROGRAM_UP_TO_DATE_ERR) {
                 (Bytes::new(), true)
             } else {
-                return Err(eyre!(
+                bail!(
                     "program predeployment check failed when checking against ARB_WASM_ADDRESS {ARB_WASM_ADDRESS}: {e}"
-                ));
+                );
             }
         }
     };
@@ -164,10 +164,10 @@ where
     }
 
     if response.len() < 2 {
-        return Err(eyre!(
+        bail!(
             "Stylus version bytes response too short, expected at least 2 bytes but got: {}",
             hex::encode(&response)
-        ));
+        );
     }
     let n = response.len();
     let version_bytes: [u8; 2] = response[n - 2..]

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -11,7 +11,7 @@ use ethers::{
     providers::{Http, Middleware, Provider},
     signers::Signer,
 };
-use eyre::eyre;
+use eyre::{bail, eyre};
 
 use crate::project::BuildConfig;
 use crate::{check, color::Color, constants, project, tx, wallet, DeployConfig, DeployMode};
@@ -101,11 +101,11 @@ on the --mode flag under cargo stylus deploy --help"#
     if !dry_run {
         let balance = provider.get_balance(addr, None).await?;
         if balance == U256::zero() {
-            return Err(eyre!(
+            bail!(
                 r#"address 0x{} has 0 balance onchain – please refer to our Quickstart guide for deploying 
 programs to Stylus chains here https://docs.arbitrum.io/stylus/stylus-quickstart"#,
                 hex::encode(addr),
-            ));
+            );
         }
     }
 
@@ -113,9 +113,9 @@ programs to Stylus chains here https://docs.arbitrum.io/stylus/stylus-quickstart
     let output_dir = cfg.tx_sending_opts.output_tx_data_to_dir.as_ref();
 
     if dry_run && output_dir.is_none() {
-        return Err(eyre!(
+        bail!(
             "using the --dry-run flag requires specifying the --output-tx-data-to-dir flag as well"
-        ));
+        );
     }
 
     if deploy {

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -55,9 +55,16 @@ pub async fn deploy(cfg: DeployConfig) -> eyre::Result<()> {
         .await
         .map_err(|e| eyre!("could not get chain id: {e}"))?
         .as_u64();
-    let client = SignerMiddleware::new(provider, wallet.clone().with_chain_id(chain_id));
+    let client = SignerMiddleware::new(&provider, wallet.clone().with_chain_id(chain_id));
 
     let addr = wallet.address();
+
+    println!(
+        "Deployer address: {}{}",
+        "0x".mint(),
+        hex::encode(&addr).mint()
+    );
+
     let nonce = client
         .get_transaction_count(addr, None)
         .await
@@ -87,6 +94,20 @@ on the --mode flag under cargo stylus deploy --help"#
 
     // Whether or not to send the transactions to the endpoint.
     let dry_run = cfg.tx_sending_opts.dry_run;
+
+    // If we are attempting to send a real transaction, we check if the deployer has any funds
+    // and we return an error, letting the user know they need funds to send the tx and linking to
+    // our quickstart on ways to do so on testnet.
+    if !dry_run {
+        let balance = provider.get_balance(addr, None).await?;
+        if balance == U256::zero() {
+            return Err(eyre!(
+                r#"address 0x{} has 0 balance onchain – please refer to our Quickstart guide on obtaining
+testnet ETH for deploying on Stylus here https://docs.arbitrum.io/stylus/stylus-quickstart"#,
+                hex::encode(addr),
+            ));
+        }
+    }
 
     // The folder at which to output the transaction data bytes.
     let output_dir = cfg.tx_sending_opts.output_tx_data_to_dir.as_ref();

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -102,8 +102,8 @@ on the --mode flag under cargo stylus deploy --help"#
         let balance = provider.get_balance(addr, None).await?;
         if balance == U256::zero() {
             return Err(eyre!(
-                r#"address 0x{} has 0 balance onchain – please refer to our Quickstart guide on obtaining
-testnet ETH for deploying on Stylus here https://docs.arbitrum.io/stylus/stylus-quickstart"#,
+                r#"address 0x{} has 0 balance onchain – please refer to our Quickstart guide for deploying 
+programs to Stylus chains here https://docs.arbitrum.io/stylus/stylus-quickstart"#,
                 hex::encode(addr),
             ));
         }

--- a/src/deploy.rs
+++ b/src/deploy.rs
@@ -62,7 +62,7 @@ pub async fn deploy(cfg: DeployConfig) -> eyre::Result<()> {
     println!(
         "Deployer address: {}{}",
         "0x".mint(),
-        hex::encode(&addr).mint()
+        hex::encode(addr).mint()
     );
 
     let nonce = client

--- a/src/export_abi.rs
+++ b/src/export_abi.rs
@@ -1,6 +1,6 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/cargo-stylus/blob/main/licenses/COPYRIGHT.md
-use eyre::eyre;
+use eyre::{bail, eyre};
 use std::{
     fs::File,
     path::PathBuf,
@@ -41,7 +41,7 @@ pub fn export_abi(release: bool, output: Option<PathBuf>) -> eyre::Result<()> {
         .output()
         .map_err(|e| eyre!("failed to execute export abi command: {e}"))?;
     if !output.status.success() {
-        return Err(eyre!("Export ABI command failed: {:?}", output));
+        return bail!("Export ABI command failed: {:?}", output);
     }
     Ok(())
 }

--- a/src/export_abi.rs
+++ b/src/export_abi.rs
@@ -1,17 +1,34 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/cargo-stylus/blob/main/licenses/COPYRIGHT.md
 use eyre::eyre;
-use std::process::{Command, Stdio};
+use std::{
+    fs::File,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
 
 /// Exports the solidity ABI a Stylus Rust program in the current directory to stdout.
-pub fn export_abi(release: bool) -> eyre::Result<()> {
+pub fn export_abi(release: bool, output: Option<PathBuf>) -> eyre::Result<()> {
     let target_host =
         rustc_host::from_cli().map_err(|e| eyre!("could not get host target architecture: {e}"))?;
-    println!("Exporting Solidity ABI for Stylus Rust program in current directory");
     let mut cmd = Command::new("cargo");
 
-    cmd.stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
+    match output.as_ref() {
+        Some(output_file_path) => {
+            let output_file = File::create(output_file_path).map_err(|e| {
+                eyre!(
+                    "could not create output file to write ABI at path {}: {e}",
+                    output_file_path.as_os_str().to_string_lossy()
+                )
+            })?;
+            cmd.stdout(output_file);
+        }
+        None => {
+            cmd.stdout(Stdio::inherit());
+        }
+    }
+
+    cmd.stderr(Stdio::inherit())
         .arg("run")
         .arg("--features=export-abi")
         .arg(format!("--target={}", target_host));

--- a/src/export_abi.rs
+++ b/src/export_abi.rs
@@ -41,7 +41,7 @@ pub fn export_abi(release: bool, output: Option<PathBuf>) -> eyre::Result<()> {
         .output()
         .map_err(|e| eyre!("failed to execute export abi command: {e}"))?;
     if !output.status.success() {
-        return bail!("Export ABI command failed: {:?}", output);
+        bail!("Export ABI command failed: {:?}", output);
     }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
-
 // Copyright 2023, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/cargo-stylus/blob/main/licenses/COPYRIGHT.md
+use std::path::PathBuf;
+
 use clap::{Args, Parser, ValueEnum};
 use color::Color;
 use ethers::types::H160;
@@ -51,6 +51,9 @@ enum StylusSubcommands {
         /// Build in release mode.
         #[arg(long)]
         release: bool,
+        /// Specify an output file to write the ABI to.
+        #[arg(long)]
+        output: Option<PathBuf>,
     },
     /// Instrument a Rust project using Stylus.
     /// This command runs compiled WASM code through Stylus instrumentation checks and reports any failures.
@@ -162,8 +165,8 @@ async fn main() -> eyre::Result<()> {
                 );
             };
         }
-        StylusSubcommands::ExportAbi { release } => {
-            if let Err(e) = export_abi::export_abi(release) {
+        StylusSubcommands::ExportAbi { release, output } => {
+            if let Err(e) = export_abi::export_abi(release, output) {
                 println!("Could not export Stylus program Solidity ABI: {}", e.red());
             };
         }

--- a/src/new.rs
+++ b/src/new.rs
@@ -1,6 +1,6 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/cargo-stylus/blob/main/licenses/COPYRIGHT.md
-use eyre::eyre;
+use eyre::{bail, eyre};
 use std::{
     env::current_dir,
     io::Write,
@@ -15,7 +15,7 @@ use crate::{color::Color, constants::GITHUB_TEMPLATE_REPOSITORY};
 /// it to the user's choosing.
 pub fn new_stylus_project(name: &str, minimal: bool) -> eyre::Result<()> {
     if name.is_empty() {
-        return Err(eyre!("cannot have an empty project name"));
+        bail!("cannot have an empty project name");
     }
     let cwd: PathBuf = current_dir().map_err(|e| eyre!("could not get current dir: {e}"))?;
     if minimal {
@@ -28,7 +28,7 @@ pub fn new_stylus_project(name: &str, minimal: bool) -> eyre::Result<()> {
             .output()
             .map_err(|e| eyre!("failed to execute cargo new: {e}"))?;
         if !output.status.success() {
-            return Err(eyre!("cargo new command failed"));
+            bail!("cargo new command failed");
         }
 
         let cargo_config_dir_path = cwd.join(name).join(".cargo");
@@ -79,7 +79,7 @@ pub fn new_stylus_project(name: &str, minimal: bool) -> eyre::Result<()> {
         .map_err(|e| eyre!("failed to execute git clone: {e}"))?;
 
     if !output.status.success() {
-        return Err(eyre!("git clone command failed"));
+        bail!("git clone command failed");
     }
     let project_path = cwd.join(name);
     println!(

--- a/src/project.rs
+++ b/src/project.rs
@@ -7,7 +7,7 @@ use std::process::{Command, Stdio};
 
 use brotli2::read::BrotliEncoder;
 use bytesize::ByteSize;
-use eyre::eyre;
+use eyre::{bail, eyre};
 
 use crate::constants::{MAX_PRECOMPRESSED_WASM_SIZE, MAX_PROGRAM_SIZE};
 use crate::{
@@ -82,7 +82,7 @@ pub fn build_project_to_wasm(cfg: BuildConfig) -> eyre::Result<PathBuf> {
             .map_err(|e| eyre!("failed to execute cargo build: {e}"))?;
 
         if !output.status.success() {
-            return Err(eyre!("cargo build command failed"));
+            bail!("cargo build command failed");
         }
     }
 

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -53,7 +53,7 @@ where
     let estimated = client
         .estimate_gas(&typed, None)
         .await
-        .map_err(|e| eyre!("not estimate gas {e}"))?;
+        .map_err(|e| eyre!("could not estimate gas {e}"))?;
 
     println!("Estimated gas for {tx_kind}: {}", estimated.pink());
 

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -4,7 +4,7 @@ use std::io::{BufRead, BufReader};
 use std::str::FromStr;
 
 use ethers::signers::LocalWallet;
-use eyre::eyre;
+use eyre::{bail, eyre};
 
 use crate::CheckConfig;
 
@@ -18,15 +18,13 @@ pub fn load(cfg: &CheckConfig) -> eyre::Result<LocalWallet> {
         ..
     } = cfg;
     if private_key.is_some() && private_key_path.is_some() {
-        return Err(eyre!(
-            "cannot provide both --private-key and --private-key-path"
-        ));
+        bail!("cannot provide both --private-key and --private-key-path");
     }
     let priv_key_flag_set = private_key.is_some() || private_key_path.is_some();
     if priv_key_flag_set
         && (keystore_opts.keystore_password_path.is_some() && keystore_opts.keystore_path.is_some())
     {
-        return Err(eyre!("must provide either (--private-key-path or --private-key) or (--keystore-path and --keystore-password-path)"));
+        bail!("must provide either (--private-key-path or --private-key) or (--keystore-path and --keystore-password-path)");
     }
 
     match (private_key.as_ref(), private_key_path.as_ref()) {


### PR DESCRIPTION
- [x] Show error if deployer has 0 balance

```
Deploy / activation command failed: address 0x8578bdcb58da7b623a634ecf25b059528fb8ceb0 has 0 balance onchain – please refer to our Quickstart guide on obtaining
testnet ETH for deploying on Stylus here https://docs.arbitrum.io/stylus/stylus-quickstart
```
- [x] Support abi export to file by itself via the `--output=` flag
- [x] Do not add extra logs to the export-abi command
- [x] Print deployer address