### PR TITLE
doc: hint in error message

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -30,7 +30,7 @@ pub struct BuildConfig {
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
 pub enum BuildError {
-    #[error("could not find WASM in release dir ({path})")]
+    #[error("could not find WASM in release dir ({path}). Hint: Do you have a main.rs?")]
     NoWasmFound { path: PathBuf },
     #[error(
         r#"compressed program size ({got}) exceeds max ({want}) despite --nightly flag. We recommend splitting up your program. 

--- a/src/project.rs
+++ b/src/project.rs
@@ -30,6 +30,20 @@ pub struct BuildConfig {
 
 #[derive(thiserror::Error, Debug, PartialEq, Eq, Clone)]
 pub enum BuildError {
+    // The text of this comment, and the error message contents including and following the word "Hint"
+    // are subject to the following license, and are reproduced here in compliance with that license.
+    // 
+    // Copyright 2023 James Prestwich
+    // 
+    // Licensed under the Apache License, Version 2.0 (the "License");
+    // you may not use this file except in compliance with the License.
+    // You may obtain a copy of the License at
+    //     http://www.apache.org/licenses/LICENSE-2.0
+    // Unless required by applicable law or agreed to in writing, software
+    // distributed under the License is distributed on an "AS IS" BASIS,
+    // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    // See the License for the specific language governing permissions and
+    // limitations under the License.
     #[error("could not find WASM in release dir ({path}). Hint: Do you have a main.rs?")]
     NoWasmFound { path: PathBuf },
     #[error(


### PR DESCRIPTION
Adds a user-facing hint to the `NoWasmFound` error. A major cause seems to be having a `lib.rs` instead of a `main.rs`

Made using web UI. Didn't run linter or anything, sorry 😅 