### PR TITLE
Detect if User Is Tracing Activation / Deployment Txs in Tracing and Exit Early

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,7 @@ dependencies = [
  "libloading",
  "parking_lot",
  "rustc-host",
+ "serde",
  "sneks",
  "tokio",
 ]
@@ -3629,9 +3630,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
@@ -3649,9 +3650,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/replay/Cargo.toml
+++ b/replay/Cargo.toml
@@ -22,5 +22,6 @@ libc.workspace = true
 libloading.workspace = true
 parking_lot.workspace = true
 rustc-host.workspace = true
+serde = { version = "1.0.203", features = ["derive"] }
 sneks.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
If a user attempts to use cargo stylus replay on a trace tx that is a program deployment or activation, they would receive weird errors. This instead adds a nicer UX in case this occurs