### PR TITLE
Allow Configurable Max Fee Per Gas in Tx Sending

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -41,3 +41,4 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          args: -- --no-deps

--- a/check/src/cache.rs
+++ b/check/src/cache.rs
@@ -90,7 +90,15 @@ pub async fn cache_program(cfg: &CacheConfig) -> Result<()> {
         }
     }
     let verbose = cfg.common_cfg.verbose;
-    let receipt = run_tx("cache", tx, None, &client, verbose).await?;
+    let receipt = run_tx(
+        "cache",
+        tx,
+        None,
+        cfg.common_cfg.max_fee_per_gas_gwei,
+        &client,
+        verbose,
+    )
+    .await?;
 
     let address = cfg.program_address.debug_lavender();
 

--- a/check/src/deploy.rs
+++ b/check/src/deploy.rs
@@ -125,6 +125,7 @@ impl DeployConfig {
             "deploy",
             tx,
             Some(gas),
+            self.check_config.common_cfg.max_fee_per_gas_gwei,
             client,
             self.check_config.common_cfg.verbose,
         )
@@ -181,6 +182,7 @@ impl DeployConfig {
             "activate",
             tx,
             Some(gas),
+            self.check_config.common_cfg.max_fee_per_gas_gwei,
             client,
             self.check_config.common_cfg.verbose,
         )
@@ -202,14 +204,18 @@ pub async fn run_tx(
     name: &str,
     tx: Eip1559TransactionRequest,
     gas: Option<U256>,
+    max_fee_per_gas_gwei: Option<U256>,
     client: &SignerClient,
     verbose: bool,
 ) -> Result<TransactionReceipt> {
-    let mut tx = TypedTransaction::Eip1559(tx);
+    let mut tx = tx;
     if let Some(gas) = gas {
-        tx.set_gas(gas);
+        tx.gas = Some(gas);
     }
-
+    if let Some(max_fee) = max_fee_per_gas_gwei {
+        tx.max_fee_per_gas = Some(gwei_to_wei(max_fee)?);
+    }
+    let tx = TypedTransaction::Eip1559(tx);
     let tx = client.send_transaction(tx, None).await?;
     let tx_hash = tx.tx_hash();
     if verbose {

--- a/check/src/main.rs
+++ b/check/src/main.rs
@@ -2,7 +2,7 @@
 // For licensing, see https://github.com/OffchainLabs/cargo-stylus/blob/main/licenses/COPYRIGHT.md
 
 use clap::{ArgGroup, Args, Parser};
-use ethers::types::H160;
+use ethers::types::{H160, U256};
 use eyre::{eyre, Context, Result};
 use std::path::PathBuf;
 use tokio::runtime::Builder;
@@ -83,6 +83,9 @@ struct DeployConfig {
     /// Only perform gas estimation.
     #[arg(long)]
     estimate_gas: bool,
+    #[arg(long)]
+    /// Optional max fee per gas in gwei units.
+    max_fee_per_gas_gwei: Option<U256>,
 }
 
 #[derive(Clone, Debug, Args)]

--- a/check/src/main.rs
+++ b/check/src/main.rs
@@ -93,6 +93,9 @@ struct CommonConfig {
     /// in project's directory tree are included.
     #[arg(long)]
     source_files_for_project_hash: Vec<String>,
+    #[arg(long)]
+    /// Optional max fee per gas in gwei units.
+    max_fee_per_gas_gwei: Option<U256>,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -132,9 +135,6 @@ struct DeployConfig {
     /// Only perform gas estimation.
     #[arg(long)]
     estimate_gas: bool,
-    #[arg(long)]
-    /// Optional max fee per gas in gwei units.
-    max_fee_per_gas_gwei: Option<U256>,
 }
 
 #[derive(Args, Clone, Debug)]


### PR DESCRIPTION
Allows for configuring a max fee per gas in gwei when deploying or activating programs via the CLI