### PR TITLE
Change default RPC to Arbitrum Sepolia

### DIFF
--- a/check/src/main.rs
+++ b/check/src/main.rs
@@ -57,7 +57,7 @@ enum Apis {
 #[derive(Args, Clone, Debug)]
 struct CheckConfig {
     /// Arbitrum RPC endpoint.
-    #[arg(short, long, default_value = "https://stylusv2.arbitrum.io/rpc")]
+    #[arg(short, long, default_value = "https://sepolia-rollup.arbitrum.io/rpc")]
     endpoint: String,
     /// The WASM to check (defaults to any found in the current directory).
     #[arg(long)]


### PR DESCRIPTION
## Description

This RPC changes the default RPC of cargo-stylus to Arbitrum Sepolia

## Checklist

- [X] I have documented these changes where necessary.
- [X] I have read the [DCO][DCO] and ensured that these changes comply.
- [X] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/cargo-stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/cargo-stylus/licenses/COPYRIGHT.md
