### PR TITLE
Fix: Ensure --version flag works correctly for cargo stylus

### DIFF
--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -34,7 +34,6 @@ enum Subcommands {
     /// Export a Solidity ABI.
     ExportAbi,
     /// Cache a contract.
-    #[command(alias = "a")]
     Cache,
     /// Check a contract.
     #[command(alias = "c")]
@@ -78,7 +77,6 @@ const COMMANDS: &[Binary] = &[
             "reproducible",
             "n",
             "x",
-            "a",
             "c",
             "d",
             "v",

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -2,7 +2,7 @@
 // For licensing, see https://github.com/OffchainLabs/cargo-stylus/blob/main/licenses/COPYRIGHT.md
 
 use cargo_stylus_util::{color::Color, sys};
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use eyre::{bail, Result};
 
 // Conditional import for Unix-specific `CommandExt`
@@ -34,7 +34,7 @@ enum Subcommands {
     /// Export a Solidity ABI.
     ExportAbi,
     /// Cache a contract.
-    #[command(alias = "c")]
+    #[command(alias = "a")]
     Cache,
     /// Check a contract.
     #[command(alias = "c")]
@@ -78,6 +78,7 @@ const COMMANDS: &[Binary] = &[
             "reproducible",
             "n",
             "x",
+            "a",
             "c",
             "d",
             "v",
@@ -102,13 +103,13 @@ const COMMANDS: &[Binary] = &[
 ];
 
 fn exit_with_help_msg() -> ! {
-    Opts::parse_from(["--help"]);
-    unreachable!()
+    Opts::command().print_help().unwrap();
+    std::process::exit(0);
 }
 
 fn exit_with_version() -> ! {
-    Opts::parse_from(["--version"]);
-    unreachable!()
+    println!("{}", Opts::command().render_version());
+    std::process::exit(0);
 }
 
 fn main() -> Result<()> {

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -102,11 +102,13 @@ const COMMANDS: &[Binary] = &[
     },
 ];
 
+// prints help message and exits
 fn exit_with_help_msg() -> ! {
     Opts::command().print_help().unwrap();
     std::process::exit(0);
 }
 
+// prints version information and exits
 fn exit_with_version() -> ! {
     println!("{}", Opts::command().render_version());
     std::process::exit(0);


### PR DESCRIPTION
Fixes #54. The changes ensure that running `cargo stylus—-version` outputs the expected version information instead of returning the help message.

Also, resolved a minor issue with the duplication of the command `check` alias `c`.

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/cargo-stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/cargo-stylus/licenses/COPYRIGHT.md
