### PR TITLE
Obtain Cache Manager Addr from ArbWasmCache Precompile + Informational Message About Cache on Deploy

### DIFF
--- a/check/src/constants.rs
+++ b/check/src/constants.rs
@@ -14,10 +14,15 @@ pub const BROTLI_COMPRESSION_LEVEL: u32 = 11;
 lazy_static! {
     /// Address of the ArbWasm precompile.
     pub static ref ARB_WASM_H160: H160 = H160(*ARB_WASM_ADDRESS.0);
+    /// Address of the ArbWasmCache precompile.
+    pub static ref ARB_WASM_CACHE_H160: H160 = H160(*ARB_WASM_CACHE_ADDRESS.0);
 }
 
 /// Address of the ArbWasm precompile.
 pub const ARB_WASM_ADDRESS: Address = address!("0000000000000000000000000000000000000071");
+
+/// Address of the ArbWasmCache precompile.
+pub const ARB_WASM_CACHE_ADDRESS: Address = address!("0000000000000000000000000000000000000072");
 
 /// Target for compiled WASM folder in a Rust project
 pub const RUST_TARGET: &str = "wasm32-unknown-unknown";

--- a/check/src/deploy.rs
+++ b/check/src/deploy.rs
@@ -141,6 +141,9 @@ impl DeployConfig {
         }
         let tx_hash = receipt.transaction_hash.debug_lavender();
         greyln!("Deployment tx hash: {tx_hash}");
+        greyln!("We recommend running cargo stylus cache --program={} to cache your activated program in ArbOS \
+        Cache programs benefit from cheaper calls to them. To read more about the Stylus program cache, see \
+        https://docs.arbitrum.io/stylus/concepts/stylus-cache-manager", address);
         Ok(contract)
     }
 

--- a/check/src/deploy.rs
+++ b/check/src/deploy.rs
@@ -141,9 +141,12 @@ impl DeployConfig {
         }
         let tx_hash = receipt.transaction_hash.debug_lavender();
         greyln!("Deployment tx hash: {tx_hash}");
-        greyln!("We recommend running cargo stylus cache --program={} to cache your activated program in ArbOS \
-        Cache programs benefit from cheaper calls to them. To read more about the Stylus program cache, see \
-        https://docs.arbitrum.io/stylus/concepts/stylus-cache-manager", address);
+        println!(
+            r#"we recommend running cargo stylus cache --address={} to cache your activated program in ArbOS.
+Cached programs benefit from cheaper calls. To read more about the Stylus program cache, see
+https://docs.arbitrum.io/stylus/concepts/stylus-cache-manager"#,
+            hex::encode(contract)
+        );
         Ok(contract)
     }
 

--- a/check/src/main.rs
+++ b/check/src/main.rs
@@ -108,9 +108,6 @@ pub struct CacheConfig {
     /// Deployed and activated program address to cache.
     #[arg(long)]
     address: H160,
-    /// Address of the Stylus program cache manager on Arbitrum chains.
-    #[arg(long, default_value = "0c9043d042ab52cfa8d0207459260040cca54253")]
-    cache_manager_address: H160,
     /// Bid, in wei, to place on the desired program to cache
     #[arg(short, long, hide(true))]
     bid: Option<u64>,


### PR DESCRIPTION
This PR fetches the stylus arbwasm cache manager addr from the arbwasmcache precompile instead of it being a flag provided by the user. Additionally, it prints an informational message telling the user they can use the stylus cache after a deployment