### PR TITLE
Trim white spaces when reading private key

### DIFF
--- a/util/src/text.rs
+++ b/util/src/text.rs
@@ -5,6 +5,7 @@ use eyre::Result;
 
 pub fn decode0x<T: AsRef<str>>(text: T) -> Result<Vec<u8>> {
     let text = text.as_ref();
+    let text = text.trim();
     let text = text.strip_prefix("0x").unwrap_or(text);
     Ok(hex::decode(text)?)
 }


### PR DESCRIPTION

## Description

This solves a common problem when there is an extra new-line in the private key file. For instance:

    Error: stylus deploy failed

    Caused by:
       0: failed to load wallet
       1: invalid private key
       2: Odd number of digits

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/cargo-stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/cargo-stylus/licenses/COPYRIGHT.md
