### PR TITLE
Fix Up Estimate Gas

### DIFF
--- a/check/src/check.rs
+++ b/check/src/check.rs
@@ -89,7 +89,7 @@ pub async fn check(cfg: &CheckConfig) -> Result<ContractCheck> {
     let address = cfg.contract_address.unwrap_or(H160::random());
     let fee = check_activate(code.clone().into(), address, &provider).await?;
     let visual_fee = format_data_fee(fee).unwrap_or("???".red());
-    greyln!("wasm data fee: {visual_fee}");
+    greyln!("wasm data fee: {visual_fee} ETH");
     Ok(ContractCheck::Ready { code, fee })
 }
 

--- a/check/src/check.rs
+++ b/check/src/check.rs
@@ -151,7 +151,7 @@ pub fn format_file_size(len: usize, mid: u64, max: u64) -> String {
 fn format_data_fee(fee: U256) -> Result<String> {
     let fee: u64 = (fee / U256::from(1e9)).try_into()?;
     let fee: f64 = fee as f64 / 1e9;
-    let text = format!("Ξ{fee:.6}");
+    let text = format!("{fee:.6}");
     Ok(if fee <= 5e14 {
         text.mint()
     } else if fee <= 5e15 {

--- a/check/src/deploy.rs
+++ b/check/src/deploy.rs
@@ -122,7 +122,7 @@ impl DeployConfig {
         if self.check_config.common_cfg.verbose || self.estimate_gas {
             let gas_price = client.get_gas_price().await?;
             greyln!("estimates");
-            greyln!("deployment gas: {}", gas.debug_lavender());
+            greyln!("deployment tx gas: {}", gas.debug_lavender());
             greyln!(
                 "gas price: {} gwei",
                 format_units(gas_price, "gwei")?.debug_lavender()
@@ -130,7 +130,7 @@ impl DeployConfig {
             let total_cost = gas_price.checked_mul(gas).unwrap_or_default();
             let eth_estimate = format_units(total_cost, "ether")?;
             greyln!(
-                "deployment total cost: {} ETH",
+                "deployment tx total cost: {} ETH",
                 eth_estimate.debug_lavender()
             );
         }

--- a/check/src/main.rs
+++ b/check/src/main.rs
@@ -121,6 +121,9 @@ pub struct ActivateConfig {
     /// Percent to bump the estimated activation data fee by. Default of 20%
     #[arg(long, default_value = "20")]
     data_fee_bump_percent: u64,
+    /// Whether or not to just estimate gas without sending a tx.
+    #[arg(long)]
+    estimate_gas: bool,
 }
 
 #[derive(Args, Clone, Debug)]


### PR DESCRIPTION
## Description

Closes #72 
Closes #76 

Ensures that estimate gas does not error, and shows deployment estimates in ETH and gas price for both deploy and activate txs
