### PR TITLE
Enforced Cargo.lock and Version in Cargo.toml for User Projects

### DIFF
--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -604,6 +604,7 @@ pub fn build_so(path: &Path) -> Result<()> {
         .current_dir(path)
         .arg("build")
         .arg("--lib")
+        .arg("--locked")
         .arg("--target")
         .arg(rustc_host::from_cli()?)
         .output()?;

--- a/main/src/project.rs
+++ b/main/src/project.rs
@@ -59,8 +59,14 @@ pub fn build_dylib(cfg: BuildConfig) -> Result<PathBuf> {
 
     let mut cmd = sys::new_command("cargo");
 
+    // Enforce a version is included in the Cargo.toml file.
+    let cargo_toml_path = cwd.join(Path::new("Cargo.toml"));
+    let cargo_toml_version = extract_cargo_toml_version(&cargo_toml_path)?;
+    greyln!("Building project with Cargo.toml version: {cargo_toml_version}");
+
     cmd.arg("build");
     cmd.arg("--lib");
+    cmd.arg("--locked");
 
     if !cfg.stable {
         cmd.arg("-Z");
@@ -201,6 +207,27 @@ pub fn extract_toolchain_channel(toolchain_file_path: &PathBuf) -> Result<String
         .collect();
 
     Ok(channel)
+}
+
+pub fn extract_cargo_toml_version(cargo_toml_path: &PathBuf) -> Result<String> {
+    let cargo_toml_contents = fs::read_to_string(cargo_toml_path)
+        .context("expected to find a Cargo.toml file in project directory")?;
+
+    let cargo_tom: Value =
+        toml::from_str(&cargo_toml_contents).context("failed to parse Cargo.toml")?;
+
+    // Extract the channel from the toolchain section
+    let Some(pkg) = toolchain_toml.get("package") else {
+        bail!("package section not found in Cargo.toml");
+    };
+
+    let Some(version) = pkg.get("version") else {
+        bail!("could not find version in project's Cargo.toml [package] section");
+    };
+    let Some(version) = version.as_str() else {
+        bail!("version in Cargo.toml's [package] section is not a string");
+    };
+    Ok(version)
 }
 
 pub fn hash_files(source_file_patterns: Vec<String>, cfg: BuildConfig) -> Result<[u8; 32]> {

--- a/main/src/project.rs
+++ b/main/src/project.rs
@@ -213,21 +213,19 @@ pub fn extract_cargo_toml_version(cargo_toml_path: &PathBuf) -> Result<String> {
     let cargo_toml_contents = fs::read_to_string(cargo_toml_path)
         .context("expected to find a Cargo.toml file in project directory")?;
 
-    let cargo_tom: Value =
+    let cargo_toml: Value =
         toml::from_str(&cargo_toml_contents).context("failed to parse Cargo.toml")?;
 
-    // Extract the channel from the toolchain section
-    let Some(pkg) = toolchain_toml.get("package") else {
+    let Some(pkg) = cargo_toml.get("package") else {
         bail!("package section not found in Cargo.toml");
     };
-
     let Some(version) = pkg.get("version") else {
         bail!("could not find version in project's Cargo.toml [package] section");
     };
     let Some(version) = version.as_str() else {
         bail!("version in Cargo.toml's [package] section is not a string");
     };
-    Ok(version)
+    Ok(version.to_string())
 }
 
 pub fn hash_files(source_file_patterns: Vec<String>, cfg: BuildConfig) -> Result<[u8; 32]> {


### PR DESCRIPTION
## Description

This PR enforces a Cargo.lock and a version existing in the Cargo.toml's [package] section of a user's project directory, to make reproducible verification safer.

Closes #88 
