### PR TITLE
Include Optional Cargo Stylus Version Flag for Verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-stylus"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "alloy-contract",
  "alloy-ethers-typecast",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-stylus-example"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Offchain Labs"]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 homepage = "https://arbitrum.io"
 license = "MIT OR Apache-2.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update && apt-get install -y git
 RUN rustup target add x86_64-unknown-linux-gnu
 RUN git clone https://github.com/offchainlabs/cargo-stylus.git
 WORKDIR /cargo-stylus
-RUN git checkout v0.5.1
+RUN git checkout v0.5.2
 RUN cargo build --release --manifest-path main/Cargo.toml
 FROM --platform=linux/amd64 rust:1.80
 COPY --from=builder /cargo-stylus/target/release/cargo-stylus /usr/local/bin/cargo-stylus

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -215,8 +215,8 @@ struct DeployConfig {
     /// builds, but at the risk of not having a reproducible contract for verification purposes.
     #[arg(long)]
     no_verify: bool,
-    /// Cargo stylus version when deploying reproducibly. If not set, uses the default version of the local
-    /// cargo stylus binary. TODO: sets in the Docker image.
+    /// Cargo stylus version when deploying reproducibly to downloads the corresponding cargo-stylus-base Docker image.
+    /// If not set, uses the default version of the local cargo stylus binary.
     #[arg(long)]
     cargo_stylus_version: Option<String>,
 }
@@ -232,8 +232,8 @@ pub struct VerifyConfig {
     /// If specified, will not run the command in a reproducible docker container. Useful for local
     /// builds, but at the risk of not having a reproducible contract for verification purposes.
     no_verify: bool,
-    /// Cargo stylus version when deploying reproducibly. If not set, uses the default version of the local
-    /// cargo stylus binary. TODO: sets in the Docker image.
+    /// Cargo stylus version when deploying reproducibly to downloads the corresponding cargo-stylus-base Docker image.
+    /// If not set, uses the default version of the local cargo stylus binary.
     #[arg(long)]
     cargo_stylus_version: Option<String>,
 }

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -215,6 +215,10 @@ struct DeployConfig {
     /// builds, but at the risk of not having a reproducible contract for verification purposes.
     #[arg(long)]
     no_verify: bool,
+    /// Cargo stylus version when deploying reproducibly. If not set, uses the default version of the local
+    /// cargo stylus binary. TODO: sets in the Docker image.
+    #[arg(long)]
+    cargo_stylus_version: Option<String>,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -228,6 +232,10 @@ pub struct VerifyConfig {
     /// If specified, will not run the command in a reproducible docker container. Useful for local
     /// builds, but at the risk of not having a reproducible contract for verification purposes.
     no_verify: bool,
+    /// Cargo stylus version when deploying reproducibly. If not set, uses the default version of the local
+    /// cargo stylus binary. TODO: sets in the Docker image.
+    #[arg(long)]
+    cargo_stylus_version: Option<String>,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -324,7 +332,7 @@ impl fmt::Display for DeployConfig {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{} {} {} {}",
+            "{} {} {} {} {}",
             self.check_config,
             self.auth,
             match self.estimate_gas {
@@ -334,6 +342,10 @@ impl fmt::Display for DeployConfig {
             match self.no_verify {
                 true => "--no-verify".to_string(),
                 false => "".to_string(),
+            },
+            match self.cargo_stylus_version.as_ref() {
+                Some(version) => format!("--cargo-stylus-version={}", version),
+                None => "".to_string(),
             },
         )
     }
@@ -368,13 +380,17 @@ impl fmt::Display for VerifyConfig {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{} --deployment-tx={} {}",
+            "{} --deployment-tx={} {} {}",
             self.common_cfg,
             self.deployment_tx,
             match self.no_verify {
                 true => "--no-verify".to_string(),
                 false => "".to_string(),
-            }
+            },
+            match self.cargo_stylus_version.as_ref() {
+                Some(version) => format!("--cargo-stylus-version={}", version),
+                None => "".to_string(),
+            },
         )
     }
 }
@@ -501,7 +517,7 @@ async fn main_impl(args: Opts) -> Result<()> {
                     .collect::<Vec<String>>();
                 commands.extend(config_args);
                 run!(
-                    docker::run_reproducible(&commands),
+                    docker::run_reproducible(config.cargo_stylus_version, &commands),
                     "failed reproducible run"
                 );
             }
@@ -523,7 +539,7 @@ async fn main_impl(args: Opts) -> Result<()> {
                     .collect::<Vec<String>>();
                 commands.extend(config_args);
                 run!(
-                    docker::run_reproducible(&commands),
+                    docker::run_reproducible(config.cargo_stylus_version, &commands),
                     "failed reproducible run"
                 );
             }


### PR DESCRIPTION
## Description

Allows a deployer and verifier doing reproducible actions in Docker to specify the cargo stylus version flag to be used in their Docker image. When Cargo stylus runs deployments or verification through Docker, it downloads an image called `cargo-stylus-base:$VERSION`. It currently defaults to the local binary's version for cargo stylus, but verifiers such as Etherscan benefit from being able to specify the user's cargo stylus version during verification
