### PR TITLE
Hotfix for Reproducible Verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,7 +1011,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-stylus"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "alloy-contract",
  "alloy-ethers-typecast",
@@ -1053,7 +1053,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-stylus-example"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Offchain Labs"]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 homepage = "https://arbitrum.io"
 license = "MIT OR Apache-2.0"

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -332,7 +332,7 @@ impl fmt::Display for DeployConfig {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{} {} {} {} {}",
+            "{} {} {} {}",
             self.check_config,
             self.auth,
             match self.estimate_gas {
@@ -342,11 +342,7 @@ impl fmt::Display for DeployConfig {
             match self.no_verify {
                 true => "--no-verify".to_string(),
                 false => "".to_string(),
-            },
-            match self.cargo_stylus_version.as_ref() {
-                Some(version) => format!("--cargo-stylus-version={}", version),
-                None => "".to_string(),
-            },
+            }
         )
     }
 }
@@ -380,17 +376,13 @@ impl fmt::Display for VerifyConfig {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{} --deployment-tx={} {} {}",
+            "{} --deployment-tx={} {}",
             self.common_cfg,
             self.deployment_tx,
             match self.no_verify {
                 true => "--no-verify".to_string(),
                 false => "".to_string(),
-            },
-            match self.cargo_stylus_version.as_ref() {
-                Some(version) => format!("--cargo-stylus-version={}", version),
-                None => "".to_string(),
-            },
+            }
         )
     }
 }


### PR DESCRIPTION
This PR removes `cargo-stylus-version` from the command that gets run in a Docker container as part of reproducible verification. Prior cargo stylus versions to 0.5.2 did not have this flag, so we do not include it when running in Docker. This allows a verifier running 0.5.3 to verify programs that were deployed with >= 0.5.0