### PR TITLE
Add Arb1 RPC as Default URL and Ignore Deprecated Cargo Stylus Extensions

### DIFF
--- a/main/src/constants.rs
+++ b/main/src/constants.rs
@@ -45,4 +45,4 @@ pub const PROJECT_HASH_SECTION_NAME: &str = "project_hash";
 pub const TOOLCHAIN_FILE_NAME: &str = "rust-toolchain.toml";
 
 /// The default endpoint for connections to a Stylus-enabled Arbitrum node.
-pub const DEFAULT_ENDPOINT: &str = "https://sepolia-rollup.arbitrum.io/rpc";
+pub const DEFAULT_ENDPOINT: &str = "https://arb1.arbitrum.io/rpc";

--- a/main/src/constants.rs
+++ b/main/src/constants.rs
@@ -45,4 +45,4 @@ pub const PROJECT_HASH_SECTION_NAME: &str = "project_hash";
 pub const TOOLCHAIN_FILE_NAME: &str = "rust-toolchain.toml";
 
 /// The default endpoint for connections to a Stylus-enabled Arbitrum node.
-pub const DEFAULT_ENDPOINT: &str = "https://arb1.arbitrum.io/rpc";
+pub const DEFAULT_ENDPOINT: &str = "http://localhost:8547";

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -415,9 +415,9 @@ fn main() -> Result<()> {
         _ => {}
     };
 
-    // see if custom extension exists
+    // see if custom extension exists and is not a deprecated extension
     let custom = format!("cargo-stylus-{arg}");
-    if sys::command_exists(&custom) {
+    if sys::command_exists(&custom) && !is_deprecated_extension(&arg) {
         let mut command = sys::new_command(&custom);
         command.arg(arg).args(args);
 
@@ -438,6 +438,16 @@ fn main() -> Result<()> {
     };
     let runtime = runtime.enable_all().build()?;
     runtime.block_on(main_impl(opts))
+}
+
+// Checks if a cargo stylus extension is an old, deprecated extension which is no longer
+// supported. These extensions are now incorporated as part of the `cargo-stylus` command itself and
+// will be the preferred method of running them.
+fn is_deprecated_extension(subcommand: &str) -> bool {
+    match subcommand {
+        "cargo-stylus-check" | "cargo-stylus-cgen" | "cargo-stylus-replay" => true,
+        _ => false,
+    }
 }
 
 async fn main_impl(args: Opts) -> Result<()> {


### PR DESCRIPTION
## Description

This PR adds the arb1 RPC as the default endpoint for cargo stylus, and also ignores custom extensions `cargo-stylus-check, cargo-stylus-cgen, cargo-stylus-replay` as those are now part of the main `cargo-stylus` binary.
