### PR TITLE
simulate api for debug trace call

### DIFF
--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -487,10 +487,10 @@ fn main() -> Result<()> {
 // supported. These extensions are now incorporated as part of the `cargo-stylus` command itself and
 // will be the preferred method of running them.
 fn is_deprecated_extension(subcommand: &str) -> bool {
-    match subcommand {
-        "cargo-stylus-check" | "cargo-stylus-cgen" | "cargo-stylus-replay" => true,
-        _ => false,
-    }
+    matches!(
+        subcommand,
+        "cargo-stylus-check" | "cargo-stylus-cgen" | "cargo-stylus-replay"
+    )
 }
 
 async fn main_impl(args: Opts) -> Result<()> {

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -4,6 +4,7 @@
 use alloy_primitives::TxHash;
 use clap::{ArgGroup, Args, CommandFactory, Parser, Subcommand};
 use constants::DEFAULT_ENDPOINT;
+use ethers::abi::Bytes;
 use ethers::types::{H160, U256};
 use eyre::{bail, eyre, Context, Result};
 use std::path::PathBuf;
@@ -297,7 +298,7 @@ pub struct SimulateArgs {
 
     /// Data to send with the transaction, as a hex string (with or without '0x' prefix).
     #[arg(short, long)]
-    data: Option<String>,
+    data: Option<Bytes>,
 
     /// Project path.
     #[arg(short, long, default_value = ".")]

--- a/main/src/trace.rs
+++ b/main/src/trace.rs
@@ -149,9 +149,9 @@ impl Trace {
                     gas.to_be_bytes().copy_from_slice(&bytes[..8]); // Convert alloy_primitives::U256 to bytes
                     ethers::types::U256::from_big_endian(&bytes) // Convert bytes to ethers::types::U256
                 })
-                .unwrap_or_else(|| ethers::types::U256::zero()), // Default to 0 if no gas is provided
+                .unwrap_or_else(ethers::types::U256::zero), // Default to 0 if no gas is provided
             gas_price: args.gas_price,
-            value: args.value.unwrap_or_else(|| ethers::types::U256::zero()),
+            value: args.value.unwrap_or_else(ethers::types::U256::zero),
             input: args.data.clone().unwrap_or_default().into(),
             // Default values for other fields
             ..Default::default()

--- a/main/src/trace.rs
+++ b/main/src/trace.rs
@@ -104,8 +104,7 @@ impl Trace {
             tx_request = tx_request.value(value);
         }
         if let Some(data) = &args.data {
-            let data_bytes = hex::decode(data.trim_start_matches("0x"))?;
-            tx_request = tx_request.data(data_bytes);
+            tx_request = tx_request.data(data.clone());
         }
 
         // Use the same tracer as in Trace::new
@@ -153,15 +152,7 @@ impl Trace {
                 .unwrap_or_else(|| ethers::types::U256::zero()), // Default to 0 if no gas is provided
             gas_price: args.gas_price,
             value: args.value.unwrap_or_else(|| ethers::types::U256::zero()),
-            input: args
-                .data
-                .as_ref()
-                .map(|d| {
-                    hex::decode(d.strip_prefix("0x").unwrap_or(&d))
-                        .unwrap_or_default()
-                        .into()
-                })
-                .unwrap_or_default(),
+            input: args.data.clone().unwrap_or_default().into(),
             // Default values for other fields
             ..Default::default()
         };


### PR DESCRIPTION
## Description
A new **simulate** API has been added to the trace, allowing users to trace their transactions without submitting them to the network. This feature enables tracing by providing transaction fields alone, streamlining the process. 

## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/cargo-stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/cargo-stylus/licenses/COPYRIGHT.md

Closes: INT-249