### PR TITLE
Write deployment and activation transaction hex data to a file

### DIFF
--- a/main/src/activate.rs
+++ b/main/src/activate.rs
@@ -17,7 +17,7 @@ use crate::check::check_activate;
 use crate::constants::ARB_WASM_H160;
 use crate::macros::greyln;
 
-use crate::ActivateConfig;
+use crate::{ActivateConfig, ActivationTxConfig};
 
 sol! {
     interface ArbWasm {
@@ -93,6 +93,17 @@ pub async fn activate_contract(cfg: &ActivateConfig) -> Result<()> {
                 cfg.address
             );
         }
+    }
+    Ok(())
+}
+
+pub async fn write_activation_tx(cfg: &ActivationTxConfig) -> Result<()> {
+    let contract: Address = cfg.address.to_fixed_bytes().into();
+    let data = ArbWasm::activateProgramCall { program: contract }.abi_encode();
+    let mut out = sys::file_or_stdout(cfg.output.clone())?;
+    out.write_all(hex::encode(&data).as_bytes())?;
+    if cfg.output.is_none() {
+        println!();
     }
     Ok(())
 }

--- a/main/src/check.rs
+++ b/main/src/check.rs
@@ -1,6 +1,7 @@
 // Copyright 2023-2024, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/cargo-stylus/blob/main/licenses/COPYRIGHT.md
 
+use crate::deploy::contract_deployment_calldata;
 use crate::util::{color::Color, sys, text};
 use crate::{
     check::ArbWasm::ArbWasmErrors,
@@ -67,6 +68,12 @@ pub async fn check(cfg: &CheckConfig) -> Result<ContractCheck> {
     // add_project_hash_to_wasm_file(wasm, project_hash)
     let (wasm_file_bytes, code) =
         project::compress_wasm(&wasm, project_hash).wrap_err("failed to compress WASM")?;
+
+    if cfg.output.is_some() {
+        let init_code = contract_deployment_calldata(code.as_slice());
+        let mut out = sys::file_or_stdout(cfg.output.clone())?;
+        out.write_all(hex::encode(&init_code).as_bytes())?;
+    }
 
     greyln!("contract size: {}", format_file_size(code.len(), 16, 24));
 

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -78,6 +78,8 @@ enum Apis {
     /// Activate an already deployed contract.
     #[command(visible_alias = "a")]
     Activate(ActivateConfig),
+    /// Generate Activation Tx.
+    ActivationTx(ActivationTxConfig),
     #[command(subcommand)]
     /// Cache a contract using the Stylus CacheManager for Arbitrum chains.
     Cache(Cache),
@@ -194,6 +196,16 @@ pub struct ActivateConfig {
 }
 
 #[derive(Args, Clone, Debug)]
+pub struct ActivationTxConfig {
+    /// Deployed Stylus contract address to activate.
+    #[arg(long)]
+    address: H160,
+    /// The activation transaction hex data file (defaults to stdout).
+    #[arg(long)]
+    output: Option<PathBuf>,
+}
+
+#[derive(Args, Clone, Debug)]
 pub struct CheckConfig {
     #[command(flatten)]
     common_cfg: CommonConfig,
@@ -203,6 +215,9 @@ pub struct CheckConfig {
     /// Where to deploy and activate the contract (defaults to a random address).
     #[arg(long)]
     contract_address: Option<H160>,
+    /// The deployment transaction hex data file.
+    #[arg(long)]
+    output: Option<PathBuf>,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -514,6 +529,12 @@ async fn main_impl(args: Opts) -> Result<()> {
             run!(
                 activate::activate_contract(&config).await,
                 "stylus activate failed"
+            );
+        }
+        Apis::ActivationTx(config) => {
+            run!(
+                activate::write_activation_tx(&config).await,
+                "stylus activation tx writing failed"
             );
         }
         Apis::Simulate(args) => {

--- a/main/src/verify.rs
+++ b/main/src/verify.rs
@@ -54,6 +54,7 @@ pub async fn verify(cfg: VerifyConfig) -> eyre::Result<()> {
         common_cfg: cfg.common_cfg.clone(),
         wasm_file: None,
         contract_address: None,
+        output: None,
     };
     let _ = check::check(&check_cfg)
         .await


### PR DESCRIPTION
## Description

An option has been added to write the hex value of the bytecode for deployment transactions to a file when running the cargo check command. 
`cargo stylus c -e https://sepolia-rollup.arbitrum.io/rpc --output deployment_tx.txt`

Additionally, the activation-tx command has been introduced to output or write the activation transaction bytecode hex to a file.
`cargo stylus activation-tx --address 0x6b48549bF9Bf2e507c745Abc9Ad7b66d48B15025 --output activation_tx.txt`

These features are currently being used when deploying Arbitrum Stylus contracts in [Remix](https://remix.ethereum.org/) through the [CODE BY WELLDONE STUDIO plugin](https://docs.welldonestudio.io/code/deploy-and-run/arbitrum). They will also be useful for developers building development tools.

## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/cargo-stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/cargo-stylus/licenses/COPYRIGHT.md
