### PR TITLE
Set from address on placeBid call

### DIFF
--- a/main/src/cache.rs
+++ b/main/src/cache.rs
@@ -168,9 +168,10 @@ pub async fn place_bid(cfg: &CacheBidConfig) -> Result<()> {
         .await?;
     let chain_id = provider.get_chain_id().await?;
     let wallet = cfg.auth.alloy_wallet(chain_id)?;
+    let from_address = wallet.default_signer().address();
     let provider = ProviderBuilder::new()
         .with_recommended_fillers()
-        .wallet(wallet.clone())
+        .wallet(wallet)
         .on_builtin(&cfg.endpoint)
         .await?;
     let cache_manager_addr = get_cache_manager_address(provider.clone()).await?;
@@ -183,7 +184,6 @@ pub async fn place_bid(cfg: &CacheBidConfig) -> Result<()> {
 
     greyln!("Checking if contract can be cached...");
 
-    let from_address = wallet.default_signer().address();
     let raw_output = place_bid_call.clone().from(from_address).call().await;
     if let Err(e) = raw_output {
         let Error::TransportError(tperr) = e else {

--- a/main/src/cache.rs
+++ b/main/src/cache.rs
@@ -170,7 +170,7 @@ pub async fn place_bid(cfg: &CacheBidConfig) -> Result<()> {
     let wallet = cfg.auth.alloy_wallet(chain_id)?;
     let provider = ProviderBuilder::new()
         .with_recommended_fillers()
-        .wallet(wallet)
+        .wallet(wallet.clone())
         .on_builtin(&cfg.endpoint)
         .await?;
     let cache_manager_addr = get_cache_manager_address(provider.clone()).await?;
@@ -183,7 +183,8 @@ pub async fn place_bid(cfg: &CacheBidConfig) -> Result<()> {
 
     greyln!("Checking if contract can be cached...");
 
-    let raw_output = place_bid_call.clone().call().await;
+    let from_address = wallet.default_signer().address();
+    let raw_output = place_bid_call.clone().from(from_address).call().await;
     if let Err(e) = raw_output {
         let Error::TransportError(tperr) = e else {
             bail!("failed to send cache bid tx: {:?}", e)


### PR DESCRIPTION
## Description

This PR fixes the issue reported in NIT-2802 where the `cargo-stylus cache bid` subcommand did not set the from address on its calls, causing the zero address to be used and calls to fail due to insufficient funds.

### Testing done
Reproduced the reported issue prior to the fix:
```
$ target/debug/cargo-stylus cargo-stylus cache bid '--endpoint=http://localhost:8547' --priv
ate-key=0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659 0x11b57fe348584f0
42e436c6bf7c3c3def171de49 2                                                                 
Checking if contract can be cached...                                                       
Error: stylus cache place bid failed                                                        
                                                                                            
Caused by:                                                                                  
    other ooga booga failed to decode CacheManager error: ErrorPayload { code: -32000, messa
ge: "err: insufficient funds for gas * price + value: address 0x0000000000000000000000000000
000000000000 have 0 want 2 (supplied gas 50000000)", data: None }                           
                                                                                            
Location:                                                                                   
    main/src/cache.rs:195:13   
```

After the fix, it appears to get past the part it was failing on earlier:
```
$ target/debug/cargo-stylus cargo-stylus cache bid '--endpoint=http://localhost:8547' --private-key=0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659 0x11b57fe348584f042e436c6bf7c3c3def171de49 1
Checking if contract can be cached...
Error: stylus cache place bid failed

Caused by:
    Your Stylus contract is not yet activated. To activate it, use the `cargo stylus activate` subcommand

Location:
    main/src/cache.rs:252:13
```

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/cargo-stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/cargo-stylus/licenses/COPYRIGHT.md
