### PR TITLE
Hashbang install.sh, include package and features replay arguments

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,5 @@
+#!/bin/sh -e
+
 cargo fmt
 cargo clippy --package cargo-stylus --package cargo-stylus-example
 cargo install --path main

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -249,6 +249,12 @@ struct ReplayArgs {
     /// Whether to use stable Rust. Note that nightly is needed to expand macros.
     #[arg(short, long)]
     stable_rust: bool,
+    /// Any features that should be passed to cargo build.
+    #[arg(short, long)]
+    features: Option<Vec<String>>,
+    /// Which specific package to build during replay, if any.
+    #[arg(long)]
+    package: Option<String>,
     /// Whether this process is the child of another.
     #[arg(short, long, hide(true))]
     child: bool,
@@ -487,10 +493,10 @@ fn main() -> Result<()> {
 // supported. These extensions are now incorporated as part of the `cargo-stylus` command itself and
 // will be the preferred method of running them.
 fn is_deprecated_extension(subcommand: &str) -> bool {
-    match subcommand {
-        "cargo-stylus-check" | "cargo-stylus-cgen" | "cargo-stylus-replay" => true,
-        _ => false,
-    }
+    matches!(
+        subcommand,
+        "cargo-stylus-check" | "cargo-stylus-cgen" | "cargo-stylus-replay"
+    )
 }
 
 async fn main_impl(args: Opts) -> Result<()> {
@@ -646,7 +652,7 @@ async fn replay(args: ReplayArgs) -> Result<()> {
     let provider = sys::new_provider(&args.trace.endpoint)?;
     let trace = Trace::new(provider, args.trace.tx, args.trace.use_native_tracer).await?;
 
-    build_so(&args.trace.project)?;
+    build_so(&args.trace.project, args.package, args.features)?;
     let so = find_so(&args.trace.project)?;
 
     // TODO: don't assume the contract is top-level
@@ -668,12 +674,19 @@ async fn replay(args: ReplayArgs) -> Result<()> {
     Ok(())
 }
 
-pub fn build_so(path: &Path) -> Result<()> {
+pub fn build_so(path: &Path, package: Option<String>, features: Option<Vec<String>>) -> Result<()> {
     let mut cargo = sys::new_command("cargo");
 
+    cargo.current_dir(path).arg("build");
+
+    if let Some(f) = features {
+        cargo.arg("--features").arg(f.join(","));
+    }
+    if let Some(p) = package {
+        cargo.arg("--package").arg(p);
+    }
+
     cargo
-        .current_dir(path)
-        .arg("build")
         .arg("--lib")
         .arg("--locked")
         .arg("--target")


### PR DESCRIPTION
## Description

Make the (executable) install.sh able to be run on its own, include an argument to the replay arguments to use a package and features field. Also restore `matches` macro use in the subcommand checking.

## Checklist

- [x] I have documented these changes where necessary.
- [X] I have read the [DCO][DCO] and ensured that these changes comply.
- [X] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/cargo-stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/cargo-stylus/licenses/COPYRIGHT.md
