### PR TITLE
Add readme to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 homepage = "https://arbitrum.io"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/OffchainLabs/cargo-stylus"
+readme = "README.md"
 
 [workspace.dependencies]
 alloy-primitives = "=0.7.7"


### PR DESCRIPTION
Let crates.io know where to find README.md so it gets rendered properly.  Will take effect when the next version is published.
