### PR TITLE
Support Docker Workspace Root Dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ dependencies = [
  "alloy-transport",
  "futures",
  "futures-util",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -185,7 +185,7 @@ dependencies = [
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -207,7 +207,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -374,7 +374,7 @@ dependencies = [
  "itertools 0.13.0",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -399,7 +399,7 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -417,7 +417,7 @@ dependencies = [
  "eth-keystore",
  "k256",
  "rand",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -501,7 +501,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tower",
  "tracing",
@@ -1051,6 +1051,7 @@ dependencies = [
  "brotli2",
  "bytes",
  "bytesize",
+ "cargo_metadata 0.19.1",
  "clap",
  "ethers",
  "eyre",
@@ -1066,7 +1067,7 @@ dependencies = [
  "sneks",
  "sys-info",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tiny-keccak",
  "tokio",
  "toml",
@@ -1095,7 +1096,21 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.8",
 ]
 
 [[package]]
@@ -1187,7 +1202,7 @@ dependencies = [
  "k256",
  "serde",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1203,7 +1218,7 @@ dependencies = [
  "pbkdf2 0.12.2",
  "rand",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1223,7 +1238,7 @@ dependencies = [
  "serde_derive",
  "sha2",
  "sha3",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1811,7 +1826,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sha3",
- "thiserror",
+ "thiserror 1.0.69",
  "uuid 0.8.2",
 ]
 
@@ -1828,7 +1843,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "thiserror",
+ "thiserror 1.0.69",
  "uint",
 ]
 
@@ -1907,7 +1922,7 @@ dependencies = [
  "pin-project",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1958,7 +1973,7 @@ checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
 dependencies = [
  "arrayvec",
  "bytes",
- "cargo_metadata",
+ "cargo_metadata 0.18.1",
  "chrono",
  "const-hex",
  "elliptic-curve",
@@ -1975,7 +1990,7 @@ dependencies = [
  "strum",
  "syn 2.0.87",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tiny-keccak",
  "unicode-xid",
 ]
@@ -1992,7 +2007,7 @@ dependencies = [
  "semver 1.0.23",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -2016,7 +2031,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-futures",
@@ -2048,7 +2063,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-tungstenite",
  "tracing",
@@ -2075,7 +2090,7 @@ dependencies = [
  "ethers-core",
  "rand",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
@@ -2103,7 +2118,7 @@ dependencies = [
  "serde_json",
  "solang-parser",
  "svm-rs",
- "thiserror",
+ "thiserror 1.0.69",
  "tiny-keccak",
  "tokio",
  "tracing",
@@ -3533,7 +3548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.69",
  "ucd-trie",
 ]
 
@@ -3880,7 +3895,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4174,7 +4189,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cca3c284cc507e641638806e7d3f162814091e0122a5b9877063b6c9c7b9f2"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4575,7 +4590,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -4637,7 +4652,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "phf",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-xid",
 ]
 
@@ -4737,7 +4752,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "zip",
 ]
@@ -4884,7 +4899,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
+dependencies = [
+ "thiserror-impl 2.0.8",
 ]
 
 [[package]]
@@ -4892,6 +4916,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5183,7 +5218,7 @@ dependencies = [
  "rand",
  "rustls",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "utf-8",
 ]
@@ -5492,7 +5527,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "wasm-bindgen-downcast",
  "wasmer-compiler",
@@ -5520,7 +5555,7 @@ dependencies = [
  "more-asserts",
  "region",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmer-types",
  "wasmer-vm",
  "wasmparser 0.95.0",
@@ -5571,7 +5606,7 @@ dependencies = [
  "more-asserts",
  "rkyv",
  "target-lexicon",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5596,7 +5631,7 @@ dependencies = [
  "more-asserts",
  "region",
  "scopeguard",
- "thiserror",
+ "thiserror 1.0.69",
  "wasmer-types",
  "winapi",
 ]
@@ -5991,7 +6026,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper 0.6.0",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ eyre = "0.6.8"
 hex = "0.4.3"
 rustc-host = "0.1.7"
 serde_json = "1.0.103"
+cargo_metadata = "0.19.1"
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread" ] }
 

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -24,6 +24,7 @@ function_name.workspace = true
 clap.workspace = true
 eyre.workspace = true
 hex.workspace = true
+cargo_metadata.workspace = true
 lazy_static.workspace = true
 ethers.workspace = true
 tokio.workspace = true

--- a/main/src/check.rs
+++ b/main/src/check.rs
@@ -4,6 +4,7 @@
 use crate::{
     check::ArbWasm::ArbWasmErrors,
     constants::{ARB_WASM_H160, ONE_ETH, TOOLCHAIN_FILE_NAME},
+    docker::find_workspace_root,
     macros::*,
     project::{self, extract_toolchain_channel, BuildConfig},
     util::{
@@ -117,7 +118,15 @@ impl CheckConfig {
         if let Some(wasm) = self.wasm_file.clone() {
             return Ok((wasm, [0u8; 32]));
         }
-        let toolchain_file_path = PathBuf::from(".").as_path().join(TOOLCHAIN_FILE_NAME);
+        let workspace_root = self.workspace_root.clone().map_or_else(
+            || find_workspace_root().map_err(|e| eyre!("failed to find workspace root: {e}")),
+            |s| Ok(PathBuf::from(s)),
+        )?;
+        println!(
+            "Found workspace root in check: {}",
+            workspace_root.to_str().unwrap()
+        );
+        let toolchain_file_path = workspace_root.join(TOOLCHAIN_FILE_NAME);
         let toolchain_channel = extract_toolchain_channel(&toolchain_file_path)?;
         let rust_stable = !toolchain_channel.contains("nightly");
         let mut cfg = BuildConfig::new(rust_stable);

--- a/main/src/check.rs
+++ b/main/src/check.rs
@@ -122,10 +122,6 @@ impl CheckConfig {
             || find_workspace_root().map_err(|e| eyre!("failed to find workspace root: {e}")),
             |s| Ok(PathBuf::from(s)),
         )?;
-        println!(
-            "Found workspace root in check: {}",
-            workspace_root.to_str().unwrap()
-        );
         let toolchain_file_path = workspace_root.join(TOOLCHAIN_FILE_NAME);
         let toolchain_channel = extract_toolchain_channel(&toolchain_file_path)?;
         let rust_stable = !toolchain_channel.contains("nightly");

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -606,7 +606,6 @@ async fn main_impl(args: Opts) -> Result<()> {
                     .filter(|s| !s.is_empty())
                     .collect::<Vec<String>>();
                 commands.extend(config_args);
-                println!("Running with commands: {:?}", &commands);
                 run!(
                     docker::run_reproducible(
                         config.cargo_stylus_version,

--- a/main/src/verify.rs
+++ b/main/src/verify.rs
@@ -57,6 +57,7 @@ pub async fn verify(cfg: VerifyConfig) -> eyre::Result<()> {
         },
         wasm_file: None,
         contract_address: None,
+        workspace_root: cfg.workspace_root,
     };
     let _ = check::check(&check_cfg)
         .await


### PR DESCRIPTION
## Description

When running a project example that has a relative dependency to a workspace, such as the erc20 below, cargo stylus deploy will fail as the Docker container does not include the absolute workspace directory to look up the dependencies.

```rs
[package]
name = "erc20"
version = "0.1.0"
edition = "2021"

[dependencies]
alloy-primitives = "=0.8.13"
alloy-sol-types = "=0.8.13"
stylus-sdk = { path = "../../stylus-sdk" }
mini-alloc = { path = "../../mini-alloc" }
```

This PR attempts to fix the issue by allowing the user to specify the workspace directory to Docker. However, this is running into issues where we don't really support workspace directories in cargo stylus. As such, will mark as a draft until we have a longer-term solution here.