### PR TITLE
Fix deprecated extension check

### DIFF
--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -485,7 +485,7 @@ fn main() -> Result<()> {
 
     // see if custom extension exists and is not a deprecated extension
     let custom = format!("cargo-stylus-{arg}");
-    if sys::command_exists(&custom) && !is_deprecated_extension(&arg) {
+    if sys::command_exists(&custom) && !is_deprecated_extension(&custom) {
         let mut command = sys::new_command(&custom);
         command.arg(arg).args(args);
 


### PR DESCRIPTION
The function call was passing the wrong parameter, so the deprecated check always returned false.
