### PR TITLE
Add support to Stylus Constructors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1039,6 +1039,7 @@ name = "cargo-stylus"
 version = "0.5.7"
 dependencies = [
  "alloy-contract",
+ "alloy-dyn-abi",
  "alloy-ethers-typecast",
  "alloy-json-abi",
  "alloy-primitives 0.7.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [workspace.dependencies]
 alloy-primitives = "=0.7.7"
+alloy-dyn-abi = "=0.7.7"
 alloy-json-abi = "=0.7.7"
 alloy-sol-macro = "=0.7.7"
 alloy-sol-types = "=0.7.7"

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -16,6 +16,7 @@ nightly = []
 
 [dependencies]
 alloy-primitives.workspace = true
+alloy-dyn-abi.workspace = true
 alloy-json-abi.workspace = true
 alloy-sol-macro.workspace = true
 alloy-sol-types.workspace = true

--- a/main/src/deploy/deployer.rs
+++ b/main/src/deploy/deployer.rs
@@ -170,9 +170,7 @@ fn get_address_from_receipt(receipt: &TransactionReceipt) -> Result<H160> {
                 if log.data.len() != 32 {
                     bail!("address missing from ContractDeployed log");
                 }
-                return Ok(ethers::types::Address::from_slice(
-                    &log.data[12..32],
-                ));
+                return Ok(ethers::types::Address::from_slice(&log.data[12..32]));
             }
         }
     }

--- a/main/src/deploy/deployer.rs
+++ b/main/src/deploy/deployer.rs
@@ -5,7 +5,7 @@ use super::SignerClient;
 use crate::{
     check::ContractCheck,
     macros::*,
-    util::color::{Color, DebugColor},
+    util::color::{Color, DebugColor, GREY},
     DeployConfig,
 };
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt, Specifier};
@@ -18,6 +18,7 @@ use ethers::{
     types::{
         transaction::eip2718::TypedTransaction, Eip1559TransactionRequest, TransactionReceipt, H160,
     },
+    utils::format_ether,
 };
 use eyre::{bail, eyre, Context, Result};
 
@@ -55,6 +56,12 @@ pub fn parse_constructor_args(
         bail!("this contract has a constructor so it requires the deployer address for deployment");
     };
 
+    if !cfg.experimental_constructor_value.is_zero() {
+        greyln!(
+            "value sent to the constructor: {} {GREY}Ether",
+            format_ether(cfg.experimental_constructor_value).debug_lavender()
+        );
+    }
     let constructor_value =
         alloy_ethers_typecast::ethers_u256_to_alloy(cfg.experimental_constructor_value);
     if constructor.state_mutability != StateMutability::Payable && !constructor_value.is_zero() {

--- a/main/src/deploy/deployer.rs
+++ b/main/src/deploy/deployer.rs
@@ -52,7 +52,7 @@ pub fn parse_constructor_args(
     contract: &ContractCheck,
 ) -> Result<DeployerArgs> {
     let Some(address) = cfg.experimental_deployer_address else {
-        bail!("missing deployer address");
+        bail!("this contract has a constructor so it requires the deployer address for deployment");
     };
 
     let constructor_value =

--- a/main/src/deploy/deployer.rs
+++ b/main/src/deploy/deployer.rs
@@ -127,7 +127,8 @@ pub async fn deploy(
 
     let gas = client
         .estimate_gas(&TypedTransaction::Eip1559(tx.clone()), None)
-        .await?;
+        .await
+        .wrap_err("deployment failed during gas estimation")?;
     if cfg.check_config.common_cfg.verbose || cfg.estimate_gas {
         super::print_gas_estimate("deployer deploy, activate, and init", client, gas).await?;
     }

--- a/main/src/deploy/factory.rs
+++ b/main/src/deploy/factory.rs
@@ -1,0 +1,192 @@
+// Copyright 2023-2024, Offchain Labs, Inc.
+// For licensing, see https://github.com/OffchainLabs/cargo-stylus/blob/main/licenses/COPYRIGHT.md
+
+use super::SignerClient;
+use crate::{
+    check::ContractCheck,
+    macros::*,
+    util::color::{Color, DebugColor},
+    DeployConfig,
+};
+use alloy_dyn_abi::{DynSolValue, JsonAbiExt, Specifier};
+use alloy_json_abi::{Constructor, StateMutability};
+use alloy_primitives::U256;
+use alloy_sol_macro::sol;
+use alloy_sol_types::{SolCall, SolEvent};
+use ethers::{
+    providers::Middleware,
+    types::{
+        transaction::eip2718::TypedTransaction, Eip1559TransactionRequest, TransactionReceipt, H160,
+    },
+};
+use eyre::{bail, eyre, Context, Result};
+
+sol! {
+    interface CargoStylusFactory {
+        event ContractDeployed(address indexed deployedContract, address indexed deployer);
+
+        function deployActivateInit(
+            bytes calldata bytecode,
+            bytes calldata constructorCalldata,
+            uint256 constructorValue
+        ) public payable returns (address);
+
+        function deployInit(
+            bytes calldata bytecode,
+            bytes calldata constructorCalldata
+        ) public payable returns (address);
+    }
+
+    function stylus_constructor();
+}
+
+pub struct FactoryArgs {
+    /// Factory address
+    address: H160,
+    /// Value to be sent in the tx
+    tx_value: U256,
+    /// Calldata to be sent in the tx
+    tx_calldata: Vec<u8>,
+}
+
+/// Parses the constructor arguments and returns the data to deploy the contract using the factory.
+pub fn parse_constructor_args(
+    cfg: &DeployConfig,
+    constructor: &Constructor,
+    contract: &ContractCheck,
+) -> Result<FactoryArgs> {
+    let Some(address) = cfg.experimental_factory_address else {
+        bail!("missing factory address");
+    };
+
+    let constructor_value =
+        alloy_ethers_typecast::ethers_u256_to_alloy(cfg.experimental_constructor_value);
+    if constructor.state_mutability != StateMutability::Payable && !constructor_value.is_zero() {
+        bail!("attempting to send Ether to non-payable constructor");
+    }
+    let tx_value = contract.suggest_fee() + constructor_value;
+
+    let args = &cfg.experimental_constructor_args;
+    let params = &constructor.inputs;
+    if args.len() != params.len() {
+        bail!(
+            "mismatch number of constructor arguments (want {}; got {})",
+            params.len(),
+            args.len()
+        );
+    }
+
+    let mut arg_values = Vec::<DynSolValue>::with_capacity(args.len());
+    for (arg, param) in args.iter().zip(params) {
+        let ty = param
+            .resolve()
+            .wrap_err_with(|| format!("could not resolve constructor arg: {param}"))?;
+        let value = ty
+            .coerce_str(arg)
+            .wrap_err_with(|| format!("could not parse constructor arg: {param}"))?;
+        arg_values.push(value);
+    }
+    let calldata_args = constructor.abi_encode_input_raw(&arg_values)?;
+
+    let mut constructor_calldata = Vec::from(stylus_constructorCall::SELECTOR);
+    constructor_calldata.extend(calldata_args);
+
+    let bytecode = super::contract_deployment_calldata(contract.code());
+    let tx_calldata = if contract.suggest_fee().is_zero() {
+        CargoStylusFactory::deployInitCall {
+            bytecode: bytecode.into(),
+            constructorCalldata: constructor_calldata.into(),
+        }
+        .abi_encode()
+    } else {
+        CargoStylusFactory::deployActivateInitCall {
+            bytecode: bytecode.into(),
+            constructorCalldata: constructor_calldata.into(),
+            constructorValue: constructor_value,
+        }
+        .abi_encode()
+    };
+
+    Ok(FactoryArgs {
+        address,
+        tx_value,
+        tx_calldata,
+    })
+}
+
+/// Deploys, activates, and initializes the contract using the Stylus factory.
+pub async fn deploy(
+    cfg: &DeployConfig,
+    factory: FactoryArgs,
+    sender: H160,
+    client: &SignerClient,
+) -> Result<()> {
+    if cfg.check_config.common_cfg.verbose {
+        greyln!(
+            "deploying contract using factory at address: {}",
+            factory.address.debug_lavender()
+        );
+    }
+
+    let tx = Eip1559TransactionRequest::new()
+        .to(factory.address)
+        .from(sender)
+        .value(alloy_ethers_typecast::alloy_u256_to_ethers(
+            factory.tx_value,
+        ))
+        .data(factory.tx_calldata);
+
+    let gas = client
+        .estimate_gas(&TypedTransaction::Eip1559(tx.clone()), None)
+        .await?;
+    if cfg.check_config.common_cfg.verbose || cfg.estimate_gas {
+        super::print_gas_estimate("factory deploy, activate, and init", client, gas).await?;
+    }
+    if cfg.estimate_gas {
+        return Ok(());
+    }
+
+    let receipt = super::run_tx(
+        "deploy_activate_init",
+        tx,
+        Some(gas),
+        cfg.check_config.common_cfg.max_fee_per_gas_gwei,
+        client,
+        cfg.check_config.common_cfg.verbose,
+    )
+    .await?;
+    let contract = get_address_from_receipt(&receipt)?;
+    let address = contract.debug_lavender();
+
+    if cfg.check_config.common_cfg.verbose {
+        let gas = super::format_gas(receipt.gas_used.unwrap_or_default());
+        greyln!(
+            "deployed code at address: {address} {} {gas}",
+            "with".grey()
+        );
+    } else {
+        greyln!("deployed code at address: {address}");
+    }
+    let tx_hash = receipt.transaction_hash.debug_lavender();
+    greyln!("deployment tx hash: {tx_hash}");
+    super::print_cache_notice(contract);
+    Ok(())
+}
+
+/// Gets the Stylus-contract address that was deployed using the factory.
+fn get_address_from_receipt(receipt: &TransactionReceipt) -> Result<H160> {
+    for log in receipt.logs.iter() {
+        if let Some(topic) = log.topics.first() {
+            if topic.0 == CargoStylusFactory::ContractDeployed::SIGNATURE_HASH {
+                let address = log
+                    .topics
+                    .get(1)
+                    .ok_or(eyre!("address missing from ContractDeployed log"))?;
+                return Ok(ethers::types::Address::from_slice(
+                    &address.as_bytes()[12..32],
+                ));
+            }
+        }
+    }
+    Err(eyre!("contract address not found in receipt"))
+}

--- a/main/src/deploy/mod.rs
+++ b/main/src/deploy/mod.rs
@@ -27,7 +27,7 @@ use ethers::{
 };
 use eyre::{bail, eyre, Result, WrapErr};
 
-mod factory;
+mod deployer;
 
 sol! {
     interface ArbWasm {
@@ -48,8 +48,8 @@ pub async fn deploy(cfg: DeployConfig) -> Result<()> {
     let verbose = cfg.check_config.common_cfg.verbose;
 
     let constructor = export_abi::get_constructor_signature()?;
-    let factory_args = constructor
-        .map(|constructor| factory::parse_constructor_args(&cfg, &constructor, &contract))
+    let deployer_args = constructor
+        .map(|constructor| deployer::parse_constructor_args(&cfg, &constructor, &contract))
         .transpose()?;
 
     let client = sys::new_provider(&cfg.check_config.common_cfg.endpoint)?;
@@ -88,8 +88,8 @@ pub async fn deploy(cfg: DeployConfig) -> Result<()> {
         }
     }
 
-    if let Some(factory_args) = factory_args {
-        return factory::deploy(&cfg, factory_args, sender, &client).await;
+    if let Some(deployer_args) = deployer_args {
+        return deployer::deploy(&cfg, deployer_args, sender, &client).await;
     }
 
     let contract_addr = cfg

--- a/main/src/export_abi.rs
+++ b/main/src/export_abi.rs
@@ -3,6 +3,7 @@
 
 use crate::macros::*;
 use crate::util::{color::Color, sys};
+use alloy_json_abi::Constructor;
 use eyre::{bail, Result, WrapErr};
 use std::{
     io::Write,
@@ -17,22 +18,7 @@ pub fn export_abi(file: Option<PathBuf>, json: bool) -> Result<()> {
         bail!("solc not found. Please see\n{link}");
     }
 
-    let target = format!("--target={}", sys::host_arch()?);
-    let mut output = Command::new("cargo")
-        .stderr(Stdio::inherit())
-        .arg("run")
-        .arg("--features=export-abi")
-        .arg(target)
-        .output()?;
-
-    if !output.status.success() {
-        let out = String::from_utf8_lossy(&output.stdout);
-        let out = (out != "")
-            .then_some(format!(": {out}"))
-            .unwrap_or_default();
-        egreyln!("failed to run contract {out}");
-        process::exit(1);
-    }
+    let mut output = run_export("abi")?;
 
     // convert the ABI to a JSON file via solc
     if json {
@@ -46,11 +32,139 @@ pub fn export_abi(file: Option<PathBuf>, json: bool) -> Result<()> {
             .wrap_err("failed to run solc")?;
 
         let mut stdin = solc.stdin.as_ref().unwrap();
-        stdin.write_all(&output.stdout)?;
-        output = solc.wait_with_output()?;
+        stdin.write_all(&output)?;
+        output = solc.wait_with_output()?.stdout;
     }
 
     let mut out = sys::file_or_stdout(file)?;
-    out.write_all(&output.stdout)?;
+    out.write_all(&output)?;
     Ok(())
+}
+
+/// Gets the constructor signature of the Stylus contract using the export binary.
+/// If the contract doesn't have a constructor, returns None.
+pub fn get_constructor_signature() -> Result<Option<Constructor>> {
+    let output = run_export("constructor")?;
+    let output = String::from_utf8(output)?;
+    parse_constructor(&output)
+}
+
+fn run_export(command: &str) -> Result<Vec<u8>> {
+    let target = format!("--target={}", sys::host_arch()?);
+    let output = Command::new("cargo")
+        .stderr(Stdio::inherit())
+        .arg("run")
+        .arg("--quiet")
+        .arg("--features=export-abi")
+        .arg(target)
+        .arg("--")
+        .arg(command)
+        .output()?;
+    if !output.status.success() {
+        let out = String::from_utf8_lossy(&output.stdout);
+        let out = (out != "")
+            .then_some(format!(": {out}"))
+            .unwrap_or_default();
+        egreyln!("failed to run contract {out}");
+        process::exit(1);
+    }
+    Ok(output.stdout)
+}
+
+fn parse_constructor(signature: &str) -> Result<Option<Constructor>> {
+    let signature = signature.trim();
+    if !signature.starts_with("constructor") {
+        // If the signature doesn't start with constructor, it is either an old SDK version that
+        // doesn't support it or the contract doesn't have one. So, it is safe to return None.
+        Ok(None)
+    } else {
+        Constructor::parse(signature)
+            .map(Some)
+            .map_err(|e| e.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_json_abi::Param;
+
+    #[test]
+    fn parse_constructors() {
+        let test_cases = vec![
+            (
+                "constructor()",
+                Some(Constructor {
+                    inputs: vec![],
+                    state_mutability: alloy_json_abi::StateMutability::NonPayable,
+                }),
+            ),
+            (
+                "constructor(uint256 foo)",
+                Some(Constructor {
+                    inputs: vec![Param {
+                        ty: "uint256".to_owned(),
+                        name: "foo".to_owned(),
+                        components: vec![],
+                        internal_type: None,
+                    }],
+                    state_mutability: alloy_json_abi::StateMutability::NonPayable,
+                }),
+            ),
+            (
+                "constructor((uint256, uint256) foo, uint8[] memory arr) payable",
+                Some(Constructor {
+                    inputs: vec![
+                        Param {
+                            ty: "tuple".to_owned(),
+                            name: "foo".to_owned(),
+                            components: vec![
+                                Param {
+                                    ty: "uint256".to_owned(),
+                                    name: "".to_owned(),
+                                    components: vec![],
+                                    internal_type: None,
+                                },
+                                Param {
+                                    ty: "uint256".to_owned(),
+                                    name: "".to_owned(),
+                                    components: vec![],
+                                    internal_type: None,
+                                },
+                            ],
+                            internal_type: None,
+                        },
+                        Param {
+                            ty: "uint8[]".to_owned(),
+                            name: "arr".to_owned(),
+                            components: vec![],
+                            internal_type: None,
+                        },
+                    ],
+                    state_mutability: alloy_json_abi::StateMutability::Payable,
+                }),
+            ),
+            ("", None),
+            (
+                "/**
+ * This file was automatically generated by Stylus and represents a Rust program.
+ * For more information, please see [The Stylus SDK](https://github.com/OffchainLabs/stylus-sdk-rs).
+ */
+
+// SPDX-License-Identifier: MIT-OR-APACHE-2.0
+pragma solidity ^0.8.23;
+
+interface ICounter  {
+    function number() external view returns (uint256);
+
+    function setNumber(uint256 new_number) external;
+}",
+                None,
+            ),
+        ];
+        for (signature, expected) in test_cases {
+            let constructor = parse_constructor(signature).expect("failed to parse");
+            assert_eq!(constructor, expected);
+        }
+    }
 }

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -4,7 +4,7 @@
 // Enable unstable test feature for benchmarks when nightly is available
 #![cfg_attr(feature = "nightly", feature(test))]
 
-use alloy_primitives::TxHash;
+use alloy_primitives::{TxHash, B256};
 use clap::{ArgGroup, Args, CommandFactory, Parser, Subcommand};
 use constants::DEFAULT_ENDPOINT;
 use ethers::abi::Bytes;
@@ -235,9 +235,12 @@ struct DeployConfig {
     /// If set, do not activate the program after deploying it
     #[arg(long)]
     no_activate: bool,
-    /// The address of the factory contract that deploys, activates, and executes the stylus constructor.
-    #[arg(long, value_name = "FACTORY_ADDRESS")]
-    experimental_factory_address: Option<H160>,
+    /// The address of the deployer contract that deploys, activates, and initializes the stylus constructor.
+    #[arg(long, value_name = "DEPLOYER_ADDRESS")]
+    experimental_deployer_address: Option<H160>,
+    /// The salt passed to the stylus deployer.
+    #[arg(long, default_value_t = B256::ZERO)]
+    experimental_deployer_salt: B256,
     /// The constructor arguments.
     #[arg(
         long,

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -235,6 +235,20 @@ struct DeployConfig {
     /// If set, do not activate the program after deploying it
     #[arg(long)]
     no_activate: bool,
+    /// The address of the factory contract that deploys, activates, and executes the stylus constructor.
+    #[arg(long, value_name = "FACTORY_ADDRESS")]
+    experimental_factory_address: Option<H160>,
+    /// The constructor arguments.
+    #[arg(
+        long,
+        num_args(0..),
+        value_name = "ARGS",
+        allow_hyphen_values = true,
+    )]
+    experimental_constructor_args: Vec<String>,
+    /// The amount of Ether sent to the contract through the constructor.
+    #[arg(long, default_value = "0")]
+    experimental_constructor_value: U256,
 }
 
 #[derive(Args, Clone, Debug)]

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -250,7 +250,7 @@ struct DeployConfig {
     )]
     experimental_constructor_args: Vec<String>,
     /// The amount of Ether sent to the contract through the constructor.
-    #[arg(long, default_value = "0")]
+    #[arg(long, value_parser = parse_ether, default_value = "0")]
     experimental_constructor_value: U256,
 }
 
@@ -783,4 +783,8 @@ pub fn find_shared_library(project: &Path, extension: &str) -> Result<PathBuf> {
         bail!("failed to find .so");
     };
     Ok(file)
+}
+
+fn parse_ether(s: &str) -> Result<U256> {
+    Ok(ethers::utils::parse_ether(s)?)
 }


### PR DESCRIPTION
This PR adds support to deploying a Stylus contract using the Stylus Factory. The factory will deploy the contract, activate it, and initialize it by calling the constructor.

First, we add a new function (`get_constructor_signature`) in the export-abi module to get the constructor signature from the export binary. This function will call the binary and pass the `constructor` subcommand to get the constructor definition. If the SDK doesn't support constructors, the function will return that no constructor is present to be backward compatible.

Then, the code that deploys the contract will call `get_constructor_signature` to decide whether it should use the factory. If no constructors are present, cargo-stylus will behave as it did previously. If the contract has a constructor, the function `factory::parse_constructor_args` will validate the CLI args to ensure there is a factory address, and it will validate the constructor arguments provided by the user match what the constructor expects. This function verifies all arguments and creates a structure that will later be used in deployment. Finally, the function `factory::deploy` deploys the contract by calling the factory.

I did a few manual tests to ensure cargo-stylus works appropriately. For future work, we should create a few end-to-end tests, making sure all cases work correctly. Here are some test cases I did:
* Deploy a contract without constructors.
* Deploy a contract with a constructor without arguments.
* Deploy a contract with a constructor with multiple arguments.
* Deploy a contract that was already activated. (Deploy the same contract twice).

