### PR TITLE
Fix replay command in MacOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,7 @@ libc = "0.2.148"
 libloading = "0.8.0"
 parking_lot = "0.12.1"
 sneks = "0.1.2"
+
+[profile.release]
+# Do not strip symbols in the release binary so the replay command can link to the HostIO symbols.
+strip = "none"

--- a/main/Cargo.toml
+++ b/main/Cargo.toml
@@ -52,3 +52,7 @@ alloy-signer-local = { version = "0.2.1", features = ["keystore"] }
 alloy-signer = "0.2.1"
 alloy-transport = "0.2.1"
 wasmprinter = "0.221.2"
+
+[profile.release]
+# Do not strip symbols in the release binary so the replay command can link to the HostIO symbols.
+strip = "none"


### PR DESCRIPTION
The replay command wasn't working on MacOS because the HostIO symbols were striped from cargo-stylus. To fix this issue, we have to disable stripping in the release profile.

This fixes introduces the following warning:

    warning: profiles for the non root package will be ignored

We have to edit the profile in the non-root package because the root package is ignored during cargo install. Otherwise, the solution won't work after the package is published to crates.io. More information about this issue is available here:

* https://github.com/rust-lang/cargo/issues/8264
* https://github.com/rust-lang/cargo/issues/11599