### PR TITLE
Remove Hardcoded Version in README and Add Nicer Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Cargo command for developing Arbitrum Stylus projects
 ### Building the Project Locally
 Install [Rust](https://www.rust-lang.org/tools/install)
 
-Clone the current released version to your local device
+Clone the latest [released version](https://github.com/OffchainLabs/cargo-stylus/releases) to your local device.
 ```
-git clone --branch v0.5.6 https://github.com/OffchainLabs/cargo-stylus.git
+git clone --branch [VERSION_TAG] https://github.com/OffchainLabs/cargo-stylus.git
 cd cargo-stylus
 ```
 


### PR DESCRIPTION
This PR removes a hardcoded version from the README.md and intercepts the common missing import error that is a result of not specifying an #[entrypoint] in contracts that users frequently run into.