### PR TITLE
Fix gas estimate and command issues

### DIFF
--- a/main/src/deploy/deployer.rs
+++ b/main/src/deploy/deployer.rs
@@ -4,9 +4,10 @@
 use super::SignerClient;
 use crate::{
     check::ContractCheck,
+    deploy::calculate_fee_per_gas,
     macros::*,
     util::color::{Color, DebugColor, GREY},
-    DeployConfig, GasFeeConfig,
+    DeployConfig,
 };
 use alloy_dyn_abi::{DynSolValue, JsonAbiExt, Specifier};
 use alloy_json_abi::{Constructor, StateMutability};
@@ -146,10 +147,7 @@ pub async fn deploy(
         return Ok(());
     }
 
-    let fee_per_gas: u128 = match cfg.check_config.common_cfg.get_max_fee_per_gas_wei()? {
-        Some(wei) => wei,
-        None => gas_price.try_into().unwrap_or_default(),
-    };
+    let fee_per_gas = calculate_fee_per_gas(&cfg.check_config.common_cfg, gas_price)?;
 
     let receipt = super::run_tx(
         "deploy_activate_init",

--- a/main/src/deploy/deployer.rs
+++ b/main/src/deploy/deployer.rs
@@ -140,12 +140,7 @@ pub async fn deploy(
     let gas_price = client.get_gas_price().await?;
 
     if cfg.check_config.common_cfg.verbose || cfg.estimate_gas {
-        super::print_gas_estimate(
-            "deployer deploy, activate, and init",
-            gas,
-            gas_price,
-        )
-        .await?;
+        super::print_gas_estimate("deployer deploy, activate, and init", gas, gas_price).await?;
     }
     if cfg.estimate_gas {
         return Ok(());

--- a/main/src/deploy/deployer.rs
+++ b/main/src/deploy/deployer.rs
@@ -142,7 +142,6 @@ pub async fn deploy(
     if cfg.check_config.common_cfg.verbose || cfg.estimate_gas {
         super::print_gas_estimate(
             "deployer deploy, activate, and init",
-            client,
             gas,
             gas_price,
         )

--- a/main/src/deploy/mod.rs
+++ b/main/src/deploy/mod.rs
@@ -238,11 +238,7 @@ impl DeployConfig {
     }
 }
 
-pub async fn print_gas_estimate(
-    name: &str,
-    gas: U256,
-    gas_price: U256,
-) -> Result<()> {
+pub async fn print_gas_estimate(name: &str, gas: U256, gas_price: U256) -> Result<()> {
     greyln!("estimates");
     greyln!("{} tx gas: {}", name, gas.debug_lavender());
     greyln!(

--- a/main/src/deploy/mod.rs
+++ b/main/src/deploy/mod.rs
@@ -147,10 +147,7 @@ impl DeployConfig {
             return Ok(ethers::utils::get_contract_address(sender, nonce));
         }
 
-        let fee_per_gas: u128 = match self.check_config.common_cfg.get_max_fee_per_gas_wei()? {
-            Some(wei) => wei,
-            None => gas_price.try_into().unwrap_or_default(),
-        };
+        let fee_per_gas = calculate_fee_per_gas(&self.check_config.common_cfg, gas_price)?;
 
         let receipt = run_tx(
             "deploy",
@@ -211,10 +208,7 @@ impl DeployConfig {
             greyln!("activation gas estimate: {}", format_gas(gas));
         }
 
-        let fee_per_gas: u128 = match self.check_config.common_cfg.get_max_fee_per_gas_wei()? {
-            Some(wei) => wei,
-            None => gas_price.try_into().unwrap_or_default(),
-        };
+        let fee_per_gas = calculate_fee_per_gas(&self.check_config.common_cfg, gas_price)?;
 
         let receipt = run_tx(
             "activate",
@@ -341,4 +335,12 @@ pub fn format_gas(gas: U256) -> String {
     } else {
         text.pink()
     }
+}
+
+pub fn calculate_fee_per_gas<T: GasFeeConfig>(config: &T, gas_price: U256) -> Result<u128> {
+    let fee_per_gas = match config.get_max_fee_per_gas_wei()? {
+        Some(wei) => wei,
+        None => gas_price.try_into().unwrap(),
+    };
+    Ok(fee_per_gas)
 }

--- a/main/src/deploy/mod.rs
+++ b/main/src/deploy/mod.rs
@@ -140,7 +140,7 @@ impl DeployConfig {
         let gas_price = client.get_gas_price().await?;
 
         if self.check_config.common_cfg.verbose || self.estimate_gas {
-            print_gas_estimate("deployment", client, gas, gas_price).await?;
+            print_gas_estimate("deployment", gas, gas_price).await?;
         }
         if self.estimate_gas {
             let nonce = client.get_transaction_count(sender, None).await?;
@@ -240,7 +240,6 @@ impl DeployConfig {
 
 pub async fn print_gas_estimate(
     name: &str,
-    client: &SignerClient,
     gas: U256,
     gas_price: U256,
 ) -> Result<()> {

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -413,7 +413,7 @@ fn convert_gwei_to_wei(fee_str: &str) -> Result<u128> {
 
     let wei = gwei * 1e9;
     if !wei.is_finite() {
-        bail!("Overflow occurred in floating point multiplication");
+        bail!("Overflow occurred in floating point multiplication of --max-fee-per-gas-gwei converting");
     }
 
     if wei < 0.0 || wei >= u128::MAX as f64 {

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -125,7 +125,7 @@ struct CommonConfig {
     source_files_for_project_hash: Vec<String>,
     #[arg(long)]
     /// Optional max fee per gas in gwei units.
-    max_fee_per_gas_gwei: Option<u128>,
+    max_fee_per_gas_gwei: Option<String>,
     /// Specifies the features to use when building the Stylus binary.
     #[arg(long)]
     features: Option<String>,
@@ -161,7 +161,7 @@ pub struct CacheBidConfig {
     bid: u64,
     #[arg(long)]
     /// Optional max fee per gas in gwei units.
-    max_fee_per_gas_gwei: Option<u128>,
+    max_fee_per_gas_gwei: Option<String>,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -392,6 +392,60 @@ impl fmt::Display for CommonConfig {
                 None => "".to_string(),
             }
         )
+    }
+}
+
+pub trait GasFeeConfig {
+    fn get_max_fee_per_gas_wei(&self) -> Result<Option<u128>>;
+    fn get_fee_str(&self) -> &Option<String>;
+}
+
+fn convert_gwei_to_wei(fee_str: &str) -> Result<u128> {
+    let gwei = match fee_str.parse::<f64>() {
+        Ok(fee) if fee >= 0.0 => fee,
+        Ok(_) => bail!("Max fee per gas must be non-negative"),
+        Err(_) => bail!("Invalid max fee per gas value: {}", fee_str),
+    };
+
+    if !gwei.is_finite() {
+        bail!("Invalid gwei value: must be finite");
+    }
+
+    let wei = gwei * 1e9;
+    if !wei.is_finite() {
+        bail!("Overflow occurred in floating point multiplication");
+    }
+
+    if wei < 0.0 || wei >= u128::MAX as f64 {
+        bail!("Result outside valid range for wei");
+    }
+
+    Ok(wei as u128)
+}
+
+impl GasFeeConfig for CommonConfig {
+    fn get_fee_str(&self) -> &Option<String> {
+        &self.max_fee_per_gas_gwei
+    }
+
+    fn get_max_fee_per_gas_wei(&self) -> Result<Option<u128>> {
+        match self.get_fee_str() {
+            Some(fee_str) => Ok(Some(convert_gwei_to_wei(fee_str)?)),
+            None => Ok(None),
+        }
+    }
+}
+
+impl GasFeeConfig for CacheBidConfig {
+    fn get_fee_str(&self) -> &Option<String> {
+        &self.max_fee_per_gas_gwei
+    }
+
+    fn get_max_fee_per_gas_wei(&self) -> Result<Option<u128>> {
+        match self.get_fee_str() {
+            Some(fee_str) => Ok(Some(convert_gwei_to_wei(fee_str)?)),
+            None => Ok(None),
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Because in rust [ethers](https://docs.rs/ethers-core/2.0.14/src/ethers_core/utils/mod.rs.html#496), the `eip1559_default_estimator` will set a high base_fee_per_gas and priority_fee to `EIP1559_FEE_ESTIMATION_DEFAULT_PRIORITY_FEE` (3_000_000_000) if network fee lower than this default value (`EIP1559_FEE_ESTIMATION_PRIORITY_FEE_TRIGGER `, 100_000_000_000), however, on arbitrum, the network fee is significant lower than this. And if the cli tool use this default fee to send tx which will cause the tx body's gas fee set super higher than what it actually needs and might lead to tx failed if users don't have that much balance in wallet.

Also, for `--max-fee-per-gas-gwei` config, it uses u128, however, user might input like `0.02` value, so we need to reset it to string and use a method to convert it.
