### PR TITLE
update cache url

### DIFF
--- a/main/src/deploy.rs
+++ b/main/src/deploy.rs
@@ -107,7 +107,7 @@ cargo stylus activate --address {}"#,
     mintln!(
         r#"NOTE: We recommend running cargo stylus cache bid {contract_addr} 0 to cache your activated contract in ArbOS.
 Cached contracts benefit from cheaper calls. To read more about the Stylus contract cache, see
-https://docs.arbitrum.io/stylus/concepts/stylus-cache-manager"#
+https://docs.arbitrum.io/stylus/how-tos/caching-contracts"#
     );
     Ok(())
 }


### PR DESCRIPTION
## Description

The current url (https://docs.arbitrum.io/stylus/concepts/stylus-cache-manage) we show is 404 now, we need to update it