### PR TITLE
skip get_constructor_signature when set wasm-file

### DIFF
--- a/main/src/deploy/mod.rs
+++ b/main/src/deploy/mod.rs
@@ -46,8 +46,13 @@ pub async fn deploy(cfg: DeployConfig) -> Result<()> {
         .await
         .expect("cargo stylus check failed");
     let verbose = cfg.check_config.common_cfg.verbose;
+    let use_wasm_file = cfg.check_config.wasm_file.is_some();
 
-    let constructor = export_abi::get_constructor_signature()?;
+    let constructor = if use_wasm_file {
+        None
+    } else {
+        export_abi::get_constructor_signature()?
+    };
     let deployer_args = constructor
         .map(|constructor| deployer::parse_constructor_args(&cfg, &constructor, &contract))
         .transpose()?;


### PR DESCRIPTION
## Description

Currently this tool will try to treat current projec as an rust sdk project (it will try to get `Cargo.toml` file and the file with export-abi) even when user set `--wasm-file=xx.wasm`, however, user in this case usually just want to provide one single xx.wasm file here to deploy and if users write the stylus program with other language will either not provide those files, so we should skip `export_abi::get_constructor_signature()` in this case.

