### PR TITLE
Add rust_features argument for the export-abi command

### DIFF
--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -79,6 +79,9 @@ enum Apis {
         /// Write a JSON ABI instead using solc. Requires solc.
         #[arg(long)]
         json: bool,
+        /// Rust crate's features list. Required to include feature specific abi.
+        #[arg(long)]
+        rust_features: Option<Vec<String>>,
     },
     /// Activate an already deployed contract.
     #[command(visible_alias = "a")]
@@ -549,8 +552,15 @@ async fn main_impl(args: Opts) -> Result<()> {
         Apis::Init { minimal } => {
             run!(new::init(minimal), "failed to initialize project");
         }
-        Apis::ExportAbi { json, output } => {
-            run!(export_abi::export_abi(output, json), "failed to export abi");
+        Apis::ExportAbi {
+            json,
+            output,
+            rust_features,
+        } => {
+            run!(
+                export_abi::export_abi(output, json, rust_features),
+                "failed to export abi"
+            );
         }
         Apis::Activate(config) => {
             run!(


### PR DESCRIPTION
## Description

Added rust_features argument for the export-abi command in order to allow to generate abi for functionality marked with feature flags in the Rust smart contract code. I faced the lack of such functionality while adding feature specific code and extending our CI. 

For now, without this changes the only possible solution would be `cargo run --quiet --features=export-abi,your-own-feature --target=your-target  -- abi`.

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/cargo-stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/cargo-stylus/licenses/COPYRIGHT.md
