### PR TITLE
Add command to print constructor

### DIFF
--- a/main/src/export_abi.rs
+++ b/main/src/export_abi.rs
@@ -46,6 +46,18 @@ pub fn export_abi(
     Ok(())
 }
 
+/// Print the constructor signature
+pub fn print_constructor(file: Option<PathBuf>, rust_features: Option<Vec<String>>) -> Result<()> {
+    let features = rust_features.map(|feature_list| feature_list.join(","));
+    let output = run_export("constructor", features)?;
+    if !std::str::from_utf8(&output)?.starts_with("constructor") {
+        return Ok(());
+    }
+    let mut file = sys::file_or_stdout(file)?;
+    file.write_all(&output)?;
+    Ok(())
+}
+
 /// Gets the constructor signature of the Stylus contract using the export binary.
 /// If the contract doesn't have a constructor, returns None.
 pub fn get_constructor_signature() -> Result<Option<Constructor>> {

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -83,6 +83,15 @@ enum Apis {
         #[arg(long)]
         rust_features: Option<Vec<String>>,
     },
+    /// Print the signature of the constructor.
+    Constructor {
+        /// The output file (defaults to stdout).
+        #[arg(long)]
+        output: Option<PathBuf>,
+        /// Rust crate's features list. Required to include feature specific abi.
+        #[arg(long)]
+        rust_features: Option<Vec<String>>,
+    },
     /// Activate an already deployed contract.
     #[command(visible_alias = "a")]
     Activate(ActivateConfig),
@@ -614,6 +623,15 @@ async fn main_impl(args: Opts) -> Result<()> {
             run!(
                 export_abi::export_abi(output, json, rust_features),
                 "failed to export abi"
+            );
+        }
+        Apis::Constructor {
+            output,
+            rust_features,
+        } => {
+            run!(
+                export_abi::print_constructor(output, rust_features),
+                "failed to print constructor"
             );
         }
         Apis::Activate(config) => {


### PR DESCRIPTION
This PR adds a simple command to print the contract constructor signature. If the contract doesn't have a constructor, it doesn't print anything.

Close https://linear.app/offchain-labs/issue/STY-231