### PR TITLE
Add contract size in bytes

### DIFF
--- a/main/src/check.rs
+++ b/main/src/check.rs
@@ -7,7 +7,7 @@ use crate::{
     macros::*,
     project::{self, extract_toolchain_channel, BuildConfig},
     util::{
-        color::{Color, GREY, LAVENDER},
+        color::{Color, GREY, LAVENDER, MINT, PINK, YELLOW},
         sys, text,
     },
     CheckConfig, DataFeeOpts,
@@ -134,13 +134,14 @@ pub fn format_file_size(len: usize, mid: u64, max: u64) -> String {
     let len = ByteSize::b(len as u64);
     let mid = ByteSize::kib(mid);
     let max = ByteSize::kib(max);
-    if len <= mid {
-        len.mint()
+    let color = if len <= mid {
+        MINT
     } else if len <= max {
-        len.yellow()
+        YELLOW
     } else {
-        len.pink()
-    }
+        PINK
+    };
+    format!("{color}{}{GREY} ({} bytes)", len, len.as_u64())
 }
 
 /// Pretty-prints a data fee.


### PR DESCRIPTION
Add the contract and wasm size in bytes after the size in kb. The output
is grayed-out and in parenthesis to avoid clutter. This can help
developers fine-tune the contract size.

    contract size: 7.2 KB (7194 bytes)
    wasm size: 19.8 KB (19760 bytes)
