### PR TITLE
Check whether constructor args are wrongly set

### DIFF
--- a/main/src/deploy/mod.rs
+++ b/main/src/deploy/mod.rs
@@ -57,6 +57,16 @@ pub async fn deploy(cfg: DeployConfig) -> Result<()> {
         .map(|constructor| deployer::parse_constructor_args(&cfg, &constructor, &contract))
         .transpose()?;
 
+    // Check constructor flags for contracts without constructor
+    if deployer_args.is_none() {
+        if cfg.experimental_deployer_address.is_some() {
+            bail!("deployer address set but constructor was not found");
+        }
+        if !cfg.experimental_constructor_args.is_empty() {
+            bail!("constructor arguments set but constructor was not found");
+        }
+    }
+
     let client = sys::new_provider(&cfg.check_config.common_cfg.endpoint)?;
     let chain_id = client.get_chainid().await.expect("failed to get chain id");
 


### PR DESCRIPTION
If cargo-stylus doesn't detect a constructor in the contract, check whether the arguments are passed by the user. If they are set, emit an error to avoid misleading the user.

Close STY-245