### PR TITLE
Command to get initcode

### DIFF
--- a/main/src/check.rs
+++ b/main/src/check.rs
@@ -10,7 +10,7 @@ use crate::{
         color::{Color, GREY, LAVENDER, MINT, PINK, YELLOW},
         sys, text,
     },
-    CheckConfig, DataFeeOpts
+    CheckConfig, DataFeeOpts,
 };
 use alloy_primitives::{Address, B256, U256};
 use alloy_sol_macro::sol;

--- a/main/src/get_initcode.rs
+++ b/main/src/get_initcode.rs
@@ -1,3 +1,6 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For licensing, see https://github.com/OffchainLabs/cargo-stylus/blob/main/licenses/COPYRIGHT.md
+
 use std::{fs::File, io::Write};
 use eyre::{Result, WrapErr};
 use crate::{deploy::contract_deployment_calldata, project, GetInitcodeConfig};

--- a/main/src/get_initcode.rs
+++ b/main/src/get_initcode.rs
@@ -1,0 +1,29 @@
+use std::{fs::File, io::Write};
+use eyre::{Result, WrapErr};
+use crate::{deploy::contract_deployment_calldata, project, GetInitcodeConfig};
+
+/// Build and print initcode for the given source
+pub fn get_initcode(cfg: &GetInitcodeConfig) -> Result<()> {
+    let (wasm, project_hash) = project::build_wasm_from_features(
+        cfg.features.clone(),
+        cfg.source_files_for_project_hash.clone(),
+    )?;
+
+    let (_, code) =
+        project::compress_wasm(&wasm, project_hash).wrap_err("failed to compress WASM")?;
+
+    let initcode = contract_deployment_calldata(&code);
+    let hex_initcode = hex::encode(initcode);
+
+    match &cfg.output {
+        Some(path) => {
+            let mut file = File::create(path).wrap_err("failed to create output file")?;
+            file.write_all(hex_initcode.as_bytes())?;
+        }
+        None => {
+            println!("{hex_initcode}");
+        }
+    }
+
+    Ok(())
+}

--- a/main/src/get_initcode.rs
+++ b/main/src/get_initcode.rs
@@ -1,9 +1,9 @@
 // Copyright 2025, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/cargo-stylus/blob/main/main/licenses/COPYRIGHT.md
 
-use std::{fs::File, io::Write};
-use eyre::{Result, WrapErr};
 use crate::{deploy::contract_deployment_calldata, project, GetInitcodeConfig};
+use eyre::{Result, WrapErr};
+use std::{fs::File, io::Write};
 
 /// Build and print initcode for the given source
 pub fn get_initcode(cfg: &GetInitcodeConfig) -> Result<()> {

--- a/main/src/get_initcode.rs
+++ b/main/src/get_initcode.rs
@@ -1,5 +1,5 @@
 // Copyright 2025, Offchain Labs, Inc.
-// For licensing, see https://github.com/OffchainLabs/cargo-stylus/blob/main/licenses/COPYRIGHT.md
+// For licensing, see https://github.com/OffchainLabs/cargo-stylus/blob/main/main/licenses/COPYRIGHT.md
 
 use std::{fs::File, io::Write};
 use eyre::{Result, WrapErr};

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -92,6 +92,8 @@ enum Apis {
     /// Check a contract.
     #[command(visible_alias = "c")]
     Check(CheckConfig),
+    #[command(visible_alias = "e")]
+    GetInitcode(CheckConfig),
     /// Deploy a contract.
     #[command(visible_alias = "d")]
     Deploy(DeployConfig),
@@ -652,6 +654,9 @@ async fn main_impl(args: Opts) -> Result<()> {
         },
         Apis::Check(config) => {
             run!(check::check(&config).await, "stylus checks failed");
+        }
+        Apis::GetInitcode(config) => {
+            run!(check::get_initcode(&config).await, "get initcode failed");
         }
         Apis::Deploy(config) => {
             if config.no_verify {

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -102,6 +102,7 @@ enum Apis {
     /// Check a contract.
     #[command(visible_alias = "c")]
     Check(CheckConfig),
+    /// Generate and print initcode for the contract
     #[command(visible_alias = "e")]
     GetInitcode(GetInitcodeConfig),
     /// Deploy a contract.
@@ -241,7 +242,8 @@ pub struct GetInitcodeConfig {
      /// Specifies the features to use when building the Stylus binary.
      #[arg(long)]
      features: Option<String>,
-     /// The output file (defaults to stdout).
+     /// The output file - text file to store generated hex code.
+     /// (defaults to stdout)
      #[arg(long)]
      output: Option<PathBuf>,
 }

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -42,6 +42,7 @@ mod trace;
 mod util;
 mod verify;
 mod wallet;
+mod get_initcode;
 
 #[derive(Parser, Debug)]
 #[command(name = "stylus")]
@@ -93,7 +94,7 @@ enum Apis {
     #[command(visible_alias = "c")]
     Check(CheckConfig),
     #[command(visible_alias = "e")]
-    GetInitcode(CheckConfig),
+    GetInitcode(GetInitcodeConfig),
     /// Deploy a contract.
     #[command(visible_alias = "d")]
     Deploy(DeployConfig),
@@ -217,6 +218,23 @@ pub struct CheckConfig {
     /// Where to deploy and activate the contract (defaults to a random address).
     #[arg(long)]
     contract_address: Option<H160>,
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct GetInitcodeConfig {
+     /// The path to source files to include in the project hash, which
+     /// is included in the contract deployment init code transaction
+     /// to be used for verification of deployment integrity.
+     /// If not provided, all .rs files and Cargo.toml and Cargo.lock files
+     /// in project's directory tree are included.
+     #[arg(long)]
+     source_files_for_project_hash: Vec<String>,
+     /// Specifies the features to use when building the Stylus binary.
+     #[arg(long)]
+     features: Option<String>,
+     /// The output file (defaults to stdout).
+     #[arg(long)]
+     output: Option<PathBuf>,
 }
 
 #[derive(Args, Clone, Debug)]
@@ -656,7 +674,7 @@ async fn main_impl(args: Opts) -> Result<()> {
             run!(check::check(&config).await, "stylus checks failed");
         }
         Apis::GetInitcode(config) => {
-            run!(check::get_initcode(&config).await, "get initcode failed");
+            run!(get_initcode::get_initcode(&config), "get initcode failed");
         }
         Apis::Deploy(config) => {
             if config.no_verify {

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -34,6 +34,7 @@ mod deploy;
 mod docker;
 mod export_abi;
 mod gen;
+mod get_initcode;
 mod hostio;
 mod macros;
 mod new;
@@ -42,7 +43,6 @@ mod trace;
 mod util;
 mod verify;
 mod wallet;
-mod get_initcode;
 
 #[derive(Parser, Debug)]
 #[command(name = "stylus")]
@@ -232,20 +232,20 @@ pub struct CheckConfig {
 
 #[derive(Args, Clone, Debug)]
 pub struct GetInitcodeConfig {
-     /// The path to source files to include in the project hash, which
-     /// is included in the contract deployment init code transaction
-     /// to be used for verification of deployment integrity.
-     /// If not provided, all .rs files and Cargo.toml and Cargo.lock files
-     /// in project's directory tree are included.
-     #[arg(long)]
-     source_files_for_project_hash: Vec<String>,
-     /// Specifies the features to use when building the Stylus binary.
-     #[arg(long)]
-     features: Option<String>,
-     /// The output file - text file to store generated hex code.
-     /// (defaults to stdout)
-     #[arg(long)]
-     output: Option<PathBuf>,
+    /// The path to source files to include in the project hash, which
+    /// is included in the contract deployment init code transaction
+    /// to be used for verification of deployment integrity.
+    /// If not provided, all .rs files and Cargo.toml and Cargo.lock files
+    /// in project's directory tree are included.
+    #[arg(long)]
+    source_files_for_project_hash: Vec<String>,
+    /// Specifies the features to use when building the Stylus binary.
+    #[arg(long)]
+    features: Option<String>,
+    /// The output file - text file to store generated hex code.
+    /// (defaults to stdout)
+    #[arg(long)]
+    output: Option<PathBuf>,
 }
 
 #[derive(Args, Clone, Debug)]


### PR DESCRIPTION
## Description

Added a command to print initcode. 
As part of this change, also extracted logic from `build_wasm` function into a common util.

e.g.
```
cargo stylus get-initcode --output initcode.txt
```

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/cargo-stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/cargo-stylus/licenses/COPYRIGHT.md
