### PR TITLE
Fix Docker build by using offchainlabs/cargo-stylus-base:0.5.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,5 @@ WORKDIR /cargo-stylus
 # Build the project using the workspace member
 RUN cargo build --release --manifest-path main/Cargo.toml
 
-FROM --platform=${BUILD_PLATFORM} rust:${RUST_VERSION} AS cargo-stylus-base
+FROM --platform=${BUILD_PLATFORM} offchainlabs/cargo-stylus-base:0.5.8 AS cargo-stylus-base
 COPY --from=builder /cargo-stylus/target/release/cargo-stylus /usr/local/bin/cargo-stylus


### PR DESCRIPTION
### Description:
This PR updates the Dockerfile to use `offchainlabs/cargo-stylus-base:0.5.8` instead of `0.5.10`, which does not exist on Docker Hub. This ensures that the build process succeeds without errors.

### Changes Made:
Updated `FROM --platform=${BUILD_PLATFORM} offchainlabs/cargo-stylus-base:0.5.10`
→ `FROM --platform=${BUILD_PLATFORM} offchainlabs/cargo-stylus-base:0.5.8`

closes #152 