### PR TITLE
Set default address for Stylus Deployer

### DIFF
--- a/main/src/deploy/deployer.rs
+++ b/main/src/deploy/deployer.rs
@@ -12,13 +12,15 @@ use alloy::{
     dyn_abi::{DynSolValue, JsonAbiExt, Specifier},
     json_abi::{Constructor, StateMutability},
     network::TransactionBuilder,
-    primitives::{utils::format_ether, Address, U256},
+    primitives::{address, utils::format_ether, Address, U256},
     providers::{Provider, ProviderBuilder},
     rpc::types::{TransactionReceipt, TransactionRequest},
     sol,
     sol_types::{SolCall, SolEvent},
 };
 use eyre::{bail, eyre, Context, Result};
+
+pub const STYLUS_DEPLOYER_ADDRESS: Address = address!("6ac4839Bfe169CadBBFbDE3f29bd8459037Bf64e");
 
 sol! {
     #[sol(rpc)]
@@ -51,10 +53,6 @@ pub async fn parse_constructor_args(
     constructor: &Constructor,
     contract: &ContractCheck,
 ) -> Result<DeployerArgs> {
-    let Some(address) = cfg.experimental_deployer_address else {
-        bail!("this contract has a constructor so it requires the deployer address for deployment");
-    };
-
     if !cfg.experimental_constructor_value.is_zero() {
         greyln!(
             "value sent to the constructor: {} {GREY}Ether",
@@ -106,7 +104,7 @@ pub async fn parse_constructor_args(
 
     let tx_calldata = deploy_call.calldata().to_vec();
     Ok(DeployerArgs {
-        address,
+        address: cfg.experimental_deployer_address,
         tx_value,
         tx_calldata,
     })

--- a/main/src/deploy/mod.rs
+++ b/main/src/deploy/mod.rs
@@ -23,6 +23,8 @@ use eyre::{bail, eyre, Result, WrapErr};
 
 mod deployer;
 
+pub use deployer::STYLUS_DEPLOYER_ADDRESS;
+
 sol! {
     #[sol(rpc)]
     interface ArbWasm {
@@ -63,13 +65,8 @@ pub async fn deploy(cfg: DeployConfig) -> Result<()> {
     };
 
     // Check constructor flags for contracts without constructor
-    if deployer_args.is_none() {
-        if cfg.experimental_deployer_address.is_some() {
-            bail!("deployer address set but constructor was not found");
-        }
-        if !cfg.experimental_constructor_args.is_empty() {
-            bail!("constructor arguments set but constructor was not found");
-        }
+    if deployer_args.is_none() && !cfg.experimental_constructor_args.is_empty() {
+        bail!("constructor arguments set but constructor was not found");
     }
 
     let provider = ProviderBuilder::new()

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -10,6 +10,7 @@ use alloy::{
 };
 use clap::{ArgGroup, Args, CommandFactory, Parser, Subcommand};
 use constants::DEFAULT_ENDPOINT;
+use deploy::STYLUS_DEPLOYER_ADDRESS;
 use eyre::{bail, eyre, Context, Result};
 use std::{
     fmt,
@@ -271,8 +272,8 @@ struct DeployConfig {
     #[arg(long)]
     no_activate: bool,
     /// The address of the deployer contract that deploys, activates, and initializes the stylus constructor.
-    #[arg(long, value_name = "DEPLOYER_ADDRESS")]
-    experimental_deployer_address: Option<Address>,
+    #[arg(long, value_name = "DEPLOYER_ADDRESS", default_value_t = STYLUS_DEPLOYER_ADDRESS)]
+    experimental_deployer_address: Address,
     /// The salt passed to the stylus deployer.
     #[arg(long, default_value_t = B256::ZERO)]
     experimental_deployer_salt: B256,


### PR DESCRIPTION
We deployed this contract using Create2, so it has the same address across all networks.

Close STY-252