### PR TITLE
Verify contract deployed with StylusDeployer

### DIFF
--- a/main/src/deploy/deployer.rs
+++ b/main/src/deploy/deployer.rs
@@ -187,3 +187,7 @@ fn get_address_from_receipt(receipt: &TransactionReceipt) -> Result<Address> {
     }
     Err(eyre!("contract address not found in receipt"))
 }
+
+pub fn decode_deploy_call(calldata: &[u8]) -> Result<StylusDeployer::deployCall> {
+    StylusDeployer::deployCall::abi_decode(calldata, true).map_err(|e| e.into())
+}

--- a/main/src/deploy/mod.rs
+++ b/main/src/deploy/mod.rs
@@ -21,7 +21,7 @@ use alloy::{
 };
 use eyre::{bail, eyre, Result, WrapErr};
 
-mod deployer;
+pub mod deployer;
 
 pub use deployer::STYLUS_DEPLOYER_ADDRESS;
 

--- a/main/src/export_abi.rs
+++ b/main/src/export_abi.rs
@@ -61,6 +61,7 @@ pub fn print_constructor(file: Option<PathBuf>, rust_features: Option<Vec<String
 /// Gets the constructor signature of the Stylus contract using the export binary.
 /// If the contract doesn't have a constructor, returns None.
 pub fn get_constructor_signature() -> Result<Option<Constructor>> {
+    greyln!("checking whether the contract has a constructor...");
     let output = run_export("constructor", None)?;
     let output = String::from_utf8(output)?;
     parse_constructor(&output)


### PR DESCRIPTION
* [Verify contract deployed with StylusDeployer](https://github.com/OffchainLabs/cargo-stylus/commit/fa303da403411de6dd198cdc540cba36bf8c69a3) 

When a contract has a constructor, its deployment transaction is a call
to StylusDeployer instead of a CREATE call. So, to verify the
deployment, the code decodes the transaction input before comparing it
with the project bytecode. The verification also prints the deployment
parameters sent to StylusDeployer.

Close [STY-257](https://linear.app/offchain-labs/issue/STY-257)

Other minor fixes included in this PR:

* [Add print to when checking for constructor](https://github.com/OffchainLabs/cargo-stylus/commit/fc8f2e00cfc6427f46a3737fac8af0fe699916e8) 
* [Remove redundant compilation step in verify](https://github.com/OffchainLabs/cargo-stylus/commit/a6108789c873a4dfa6870625758c6f7e3cf7dc54) 