### PR TITLE
Fix cargo stylus replay

### DIFF
--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -826,10 +826,10 @@ async fn replay(args: ReplayArgs) -> Result<()> {
     let shared_library = find_shared_library(&args.trace.project, library_extension)?;
 
     // TODO: don't assume the contract is top-level
-    let args_len = match &trace.tx.input.data {
-        Some(data) => data.len(),
-        None => 0,
+    let Some(args) = trace.tx.input.input() else {
+        bail!("missing transaction input");
     };
+    let args_len = args.len();
 
     unsafe {
         *hostio::FRAME.lock() = Some(trace.reader());


### PR DESCRIPTION
The main binary failed to get the input data from the transaction. Solve the issue by calling the correct method.

Close STY-267