### PR TITLE
Remove experimental prefix from deployer flags

### DIFF
--- a/main/src/deploy/deployer.rs
+++ b/main/src/deploy/deployer.rs
@@ -53,19 +53,19 @@ pub async fn parse_constructor_args(
     constructor: &Constructor,
     contract: &ContractCheck,
 ) -> Result<DeployerArgs> {
-    if !cfg.experimental_constructor_value.is_zero() {
+    if !cfg.constructor_value.is_zero() {
         greyln!(
             "value sent to the constructor: {} {GREY}Ether",
-            format_ether(cfg.experimental_constructor_value).debug_lavender()
+            format_ether(cfg.constructor_value).debug_lavender()
         );
     }
-    let constructor_value = cfg.experimental_constructor_value;
+    let constructor_value = cfg.constructor_value;
     if constructor.state_mutability != StateMutability::Payable && !constructor_value.is_zero() {
         bail!("attempting to send Ether to non-payable constructor");
     }
     let tx_value = contract.suggest_fee() + constructor_value;
 
-    let args = &cfg.experimental_constructor_args;
+    let args = &cfg.constructor_args;
     let params = &constructor.inputs;
     if args.len() != params.len() {
         bail!(
@@ -99,12 +99,12 @@ pub async fn parse_constructor_args(
         bytecode.into(),
         constructor_calldata.into(),
         constructor_value,
-        cfg.experimental_deployer_salt,
+        cfg.deployer_salt,
     );
 
     let tx_calldata = deploy_call.calldata().to_vec();
     Ok(DeployerArgs {
-        address: cfg.experimental_deployer_address,
+        address: cfg.deployer_address,
         tx_value,
         tx_calldata,
     })

--- a/main/src/deploy/mod.rs
+++ b/main/src/deploy/mod.rs
@@ -44,13 +44,13 @@ pub async fn deploy(cfg: DeployConfig) -> Result<()> {
     let use_wasm_file = cfg.check_config.wasm_file.is_some();
 
     let constructor = if use_wasm_file {
-        if let Some(signature) = &cfg.experimental_constructor_signature {
+        if let Some(signature) = &cfg.constructor_signature {
             Some(Constructor::parse(signature)?)
         } else {
             None
         }
     } else {
-        if cfg.experimental_constructor_signature.is_some() {
+        if cfg.constructor_signature.is_some() {
             bail!("cannot set constructor signature without --wasm-file");
         }
         export_abi::get_constructor_signature()?
@@ -65,7 +65,7 @@ pub async fn deploy(cfg: DeployConfig) -> Result<()> {
     };
 
     // Check constructor flags for contracts without constructor
-    if deployer_args.is_none() && !cfg.experimental_constructor_args.is_empty() {
+    if deployer_args.is_none() && !cfg.constructor_args.is_empty() {
         bail!("constructor arguments set but constructor was not found");
     }
 
@@ -84,7 +84,7 @@ pub async fn deploy(cfg: DeployConfig) -> Result<()> {
         greyln!("sender address: {}", from_address.debug_lavender());
     }
 
-    let data_fee = contract.suggest_fee() + cfg.experimental_constructor_value;
+    let data_fee = contract.suggest_fee() + cfg.constructor_value;
 
     if let ContractCheck::Ready { .. } = &contract {
         // check balance early

--- a/main/src/export_abi.rs
+++ b/main/src/export_abi.rs
@@ -82,7 +82,7 @@ fn run_export(command: &str, features: Option<String>) -> Result<Vec<u8>> {
         .output()?;
     if !output.status.success() {
         let out = String::from_utf8_lossy(&output.stdout);
-        let out = (out != "")
+        let out = (!out.is_empty())
             .then_some(format!(": {out}"))
             .unwrap_or_default();
         egreyln!("failed to run contract {out}");

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -273,10 +273,10 @@ struct DeployConfig {
     no_activate: bool,
     /// The address of the deployer contract that deploys, activates, and initializes the stylus constructor.
     #[arg(long, value_name = "DEPLOYER_ADDRESS", default_value_t = STYLUS_DEPLOYER_ADDRESS)]
-    experimental_deployer_address: Address,
+    deployer_address: Address,
     /// The salt passed to the stylus deployer.
     #[arg(long, default_value_t = B256::ZERO)]
-    experimental_deployer_salt: B256,
+    deployer_salt: B256,
     /// The constructor arguments.
     #[arg(
         long,
@@ -284,13 +284,13 @@ struct DeployConfig {
         value_name = "ARGS",
         allow_hyphen_values = true,
     )]
-    experimental_constructor_args: Vec<String>,
+    constructor_args: Vec<String>,
     /// The amount of Ether sent to the contract through the constructor.
     #[arg(long, value_parser = parse_ether, default_value = "0")]
-    experimental_constructor_value: U256,
+    constructor_value: U256,
     /// The constructor signature when using the --wasm-file flag.
     #[arg(long)]
-    experimental_constructor_signature: Option<String>,
+    constructor_signature: Option<String>,
 }
 
 #[derive(Args, Clone, Debug)]

--- a/main/src/verify.rs
+++ b/main/src/verify.rs
@@ -64,7 +64,7 @@ pub async fn verify(cfg: VerifyConfig) -> Result<()> {
     let contract_check = check::check(&check_cfg)
         .await
         .map_err(|e| eyre!("Stylus checks failed: {e}"))?;
-    let deployment_data = deploy::contract_deployment_calldata(&contract_check.code());
+    let deployment_data = deploy::contract_deployment_calldata(contract_check.code());
     let calldata = tx.input();
     if let Some(deployer_address) = tx.to() {
         verify_constructor_deployment(deployer_address, calldata, &deployment_data)


### PR DESCRIPTION
We should now remove this prefix, as we have released the SDK version 0.9.0.

Close STY-247