### PR TITLE
Add docker bake

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,6 @@
+target "default" {
+  context = "."
+  dockerfile = "Dockerfile"
+  tags = ["offchainlabs/cargo-stylus-base:0.6.1"]
+  platform = ["linux/amd64"]
+}


### PR DESCRIPTION
Allow building docker with `docker buildx bake` setting the correct tag and architecture.
