### PR TITLE
Fix verifiable deployment for constructors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,7 +1199,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-stylus"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "alloy",
  "brotli2",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-stylus-example"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "clap",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Offchain Labs"]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 homepage = "https://arbitrum.io"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Properly display all fields in the deployment config struct.
Also, add some unit tests to avoid regressions.

Close NIT-3739